### PR TITLE
g5_path function 수정

### DIFF
--- a/common.php
+++ b/common.php
@@ -35,7 +35,7 @@ function g5_path()
     $port = $_SERVER['SERVER_PORT'] != 80 ? ':'.$_SERVER['SERVER_PORT'] : '';
     $http = 'http' . ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']=='on') ? 's' : '') . '://';
     $user = str_replace(str_replace($document_root, '', $_SERVER['SCRIPT_FILENAME']), '', $_SERVER['SCRIPT_NAME']);
-    $result['url'] = $http.$_SERVER['SERVER_NAME'].$port.$user.$root;
+    $result['url'] = $http.$_SERVER['HTTP_HOST'].$port.$user.$root;
     return $result;
 }
 


### PR DESCRIPTION
nginx-php가 설치된 서버환경에서 설치 시 SERVER_NAME의 값이 localhost로 나와 설치 후 g5_path에 오류가 있어 HTTP_HOST로 대체했습니다.

http://serverfault.com/questions/496597/php-fpm-server-name-sub-domains-using-nginx
