### PR TITLE
san-serif체 기본 적용

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -2,7 +2,7 @@
 /* SIR 지운아빠 */
 
 /* 초기화 */
-* {font-family:sans-serif}
+* {font-family:dotum, sans-serif}
 html {overflow-y:scroll}
 body {margin:0;padding:0;font-size:0.75em}
 html, h1, h2, h3, h4, h5, h6, form, fieldset, img {margin:0;padding:0;border:0}

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -2,7 +2,7 @@
 /* SIR 지운아빠 */
 
 /* 초기화 */
-* {font-family:sans-serif}
+* {font-family:dotum, sans-serif}
 html {overflow-y:scroll}
 body {margin:0;padding:0;font-size:0.75em}
 html, h1, h2, h3, h4, h5, h6, form, fieldset, img {margin:0;padding:0;border:0}


### PR DESCRIPTION
윈도우 외 os에는 웬만해서는 돋움체가 기본으로 들어있지 않아 폰트가 이상한 폰트로 나와 san-serif체를 기본 적용하도록 했습니다.
