### PR TITLE
empty_mb_name checks mb_id, not mb_name

### DIFF
--- a/bbs/register_form_update.php
+++ b/bbs/register_form_update.php
@@ -73,7 +73,7 @@ if ($w == '' || $w == 'u') {
     if($w == '' && $mb_password != $mb_password_re)
         alert('비밀번호가 일치하지 않습니다.');
 
-    if ($msg = empty_mb_name($mb_id))       alert($msg, "", true, true);
+    if ($msg = empty_mb_name($mb_name))       alert($msg, "", true, true);
     if ($msg = empty_mb_nick($mb_nick))     alert($msg, "", true, true);
     if ($msg = empty_mb_email($mb_email))   alert($msg, "", true, true);
     if ($msg = reserve_mb_id($mb_id))       alert($msg, "", true, true);


### PR DESCRIPTION
empty_mb_name is a function checking name from user input form. But it
was not checked by empty_mb_name function. So I fix it. 
(and it is my first commit, so I have some mistake about this pull request. plz understand it. thanks)