### PR TITLE
브라우저의 새로고침없이 변경된 js 파일이 로딩되도록 주소 뒤에 그누보드 버전 추가

### DIFF
--- a/adm/admin.tail.php
+++ b/adm/admin.tail.php
@@ -21,7 +21,7 @@ if (!defined('_GNUBOARD_')) exit;
 
 <!-- <p>실행시간 : <?php echo get_microtime() - $begin_time; ?> -->
 
-<script src="<?php echo G5_ADMIN_URL ?>/admin.js"></script>
+<script src="<?php echo G5_ADMIN_URL ?>/admin.js?v=<?php echo G5_GNUBOARD_VER ?>"></script>
 <script>
 $(function(){
     var hide_menu = false;

--- a/adm/board_copy.php
+++ b/adm/board_copy.php
@@ -8,7 +8,7 @@ $g5['title'] = '게시판 복사';
 include_once(G5_PATH.'/head.sub.php');
 ?>
 
-<script src="<?php echo G5_ADMIN_URL ?>/admin.js"></script>
+<script src="<?php echo G5_ADMIN_URL ?>/admin.js?v=<?php echo G5_GNUBOARD_VER ?>"></script>
 
 <div class="new_win">
     <h1><?php echo $g5['title']; ?></h1>


### PR DESCRIPTION
업데이트에 항상 수고 많습니다. :)

이번 5.1.8 패치를 보면, 다음 안내 문구가 있는데요.

`패치 후 브라우저 화면 새로고침을 여러 번 실행하셔서 캐시를 갱신해주시기 바랍니다. `

그누보드 버전 업데이트시  js 주소가 자동으로 바뀌어, 브라우저 새로고침이 필요없도록 개선했습니다.   

일단 관리자모드에서만 적용해봤는데, 사용자단(head.sub.php)의 css, js 에도 적용하는 것을 한번 고려해봐주세요.

---

### 참고

그누보드 공식 사이트에서 사용하는 기법과 유사한데, 그누보드 버전에 연동되도록 해둔 것 입니다.

```html
<link rel="stylesheet" href="//sir.co.kr/css/default.css?v=20151125">
<script src="//sir.co.kr/js/common.js?v=20151125"></script>
```