### PR TITLE
/lib/common.lib.php 보안 패치

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -1469,12 +1469,11 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
 
     // Blind SQL Injection 취약점 해결
     $sql = trim($sql);
-    $sql = str_replace("\n", " ", $sql);
     // union의 사용을 허락하지 않습니다.
     //$sql = preg_replace("#^select.*from.*union.*#i", "select 1", $sql);
-    $sql = preg_replace("#^select.*from.*[\s\(]+union[\s\)]+.*#i ", "select 1", $sql);
+    $sql = preg_replace("#^select.*from.*[\s\(]+union[\s\)]+.*#i ", "select 1", str_replace("\n", " ", $sql));
     // `information_schema` DB로의 접근을 허락하지 않습니다.
-    $sql = preg_replace("#^select.*from.*where.*`?information_schema`?.*#i", "select 1", $sql);
+    $sql = preg_replace("#^select.*from.*where.*`?information_schema`?.*#i", "select 1", str_replace("\n", " ", $sql));
 
     if(function_exists('mysqli_query') && G5_MYSQLI_USE) {
         if ($error) {

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -1469,6 +1469,7 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
 
     // Blind SQL Injection 취약점 해결
     $sql = trim($sql);
+    $sql = str_replace("\n", " ", $sql);
     // union의 사용을 허락하지 않습니다.
     //$sql = preg_replace("#^select.*from.*union.*#i", "select 1", $sql);
     $sql = preg_replace("#^select.*from.*[\s\(]+union[\s\)]+.*#i ", "select 1", $sql);


### PR DESCRIPTION
정규표현식 '.'은 '\n'(계행)을 제외한 문자열을 나타냅니다.
그래서 '\n'을 주의깊게 예외처리 안해주면 우회가 가능합니다.

만약 파라미터 no로 sql 인젝션이 가능할 때 
$user_input = $_GET['no'];
select id, no from user_tb where id = user and no=$user_input

다음과 같이 페이로드를 입력할 시 기존 정규표현식을 패스하고 유니온 사용이 가능합니다.
http://example.co.kr/?no = 7 or 1 =%0a (1) union select ('admin', 1) limit 1

mysql> select id, no from user_tb where id = user and no=7 or 1 =
    -> (1) union select ('admin', 1) limit 1
+-------+----------+
| id    | no       |
+-------+----------+
| admin | 1 |
+-------+----------+

2.
다음 부분도 계행을 이용하면 쉽게 바이패스가 가능합니다.
$sql = preg_replace("#^select._from._where._`?information_schema`?._#i", "select 1", $sql);
%0a information_schema ~~

정규표현식으로 계행을 처리할 수도 있지만 str_replace를 통해 정규표현식 .*에 대한 예외상황을 만들지 않는게 가장 효과적입니다.
