### PR TITLE
유효하지 않은 HTTP_X_FORWARDED_FOR 값을 무시하게 변경.

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3423,7 +3423,7 @@ function is_use_email_certify(){
 
 function get_real_client_ip(){
 
-    if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+    if( isset($_SERVER['HTTP_X_FORWARDED_FOR']) && filter_var($_SERVER['HTTP_X_FORWARDED_FOR'], FILTER_VALIDATE_IP) )
         return $_SERVER['HTTP_X_FORWARDED_FOR'];
 
     return $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
사용자는 임의로 HTTP_X_FORWARDED_FOR 헤더를 추가해서 서버요청 할 수 있음.
현재의 그누보드 소스상으로는 이 부분 관련 취약점이 없는데, 
3rd party 코드나, 로드밸런서(프록시)등 연동하면서 get_real_client_ip 를 신뢰된 값으로 간주하여 사용할 경우 sql injection 같은 문제가 발생할 수도 있음.