### PR TITLE
보안을 위해 RAR Wrapper 차단

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3489,8 +3489,9 @@ function is_include_path_check($path='', $is_input='')
 {
     if( $path ){
         if ($is_input){
-
-            if( stripos($path, 'php:') !== false || stripos($path, 'zlib:') !== false || stripos($path, 'bzip2:') !== false || stripos($path, 'zip:') !== false || stripos($path, 'data:') !== false || stripos($path, 'phar:') !== false ){
+            // 장태진 @jtjisgod <jtjisgod@gmail.com> 추가
+            // 보안 목적 : rar wrapper 차단
+            if( stripos($path, 'rar:') !== false || stripos($path, 'php:') !== false || stripos($path, 'zlib:') !== false || stripos($path, 'bzip2:') !== false || stripos($path, 'zip:') !== false || stripos($path, 'data:') !== false || stripos($path, 'phar:') !== false ){
                 return false;
             }
 


### PR DESCRIPTION
@Author : jtjisgod <jtjisgod@gmail.com>

LFI/RFI 공격 차단을 위한 rar wrapper 차단.
zip wrapper 와 비슷한 공격 페이로드고 공격 가능