### PR TITLE
common.php에 date_default_timezone_set() 사용시 PHP버전 확인 삭제

### DIFF
--- a/config.php
+++ b/config.php
@@ -10,10 +10,8 @@ define('G5_GNUBOARD_VER', '5.4.3');
 // 이 상수가 정의되지 않으면 각각의 개별 페이지는 별도로 실행될 수 없음
 define('_GNUBOARD_', true);
 
-if (PHP_VERSION >= '5.1.0') {
-    //if (function_exists("date_default_timezone_set")) date_default_timezone_set("Asia/Seoul");
-    date_default_timezone_set("Asia/Seoul");
-}
+// 기본 시간대 설정
+date_default_timezone_set("Asia/Seoul"); 
 
 /********************
     경로 상수


### PR DESCRIPTION
common.php 에는 그누보드가  작동하는 최소 PHP 버전인 5.2.17 이상이라고 되어있는데
date_default_timezone_set 함수는 5.1.0 이상이면 동작해서 PHP 버전 체크가 필요없습니다.