### PR TITLE
Fix error handling ITEM_ID value exception on naverpay_item.php page

### DIFF
--- a/shop/naverpay/naverpay_item.php
+++ b/shop/naverpay/naverpay_item.php
@@ -1,12 +1,12 @@
 <?php
 include_once('./_common.php');
-include_once(G5_LIB_PATH.'/naverpay.lib.php');
+include_once(G5_LIB_PATH . '/naverpay.lib.php');
 
 $query = $_SERVER['QUERY_STRING'];
 
 $vars = array();
 
-foreach(explode('&', $query) as $pair) {
+foreach (explode('&', $query) as $pair) {
     list($key, $value) = explode('=', $pair);
     $key = urldecode($key);
     $value = preg_replace("/[^A-Za-z0-9\-_]/", "", urldecode($value));
@@ -15,7 +15,7 @@ foreach(explode('&', $query) as $pair) {
 
 $itemIds = $vars['ITEM_ID'];
 
-if (count($itemIds) < 1) {
+if (is_null($itemIds) || count($itemIds) < 1) {
     exit('ITEM_ID 는 필수입니다.');
 }
 
@@ -23,56 +23,68 @@ header('Content-Type: application/xml;charset=utf-8');
 echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
 <response>
-<?php
-foreach($itemIds as $it_id) {
-    $it = get_shop_item($it_id, true);
-    if(!$it['it_id'])
-        continue;
+    <?php
+    foreach ($itemIds as $it_id) {
+        $it = get_shop_item($it_id, true);
+        if (!$it['it_id'])
+            continue;
 
-    $id          = $it['it_id'];
-    $name        = $it['it_name'];
-    $description = $it['it_basic'];
-    $price       = get_price($it);
-    $image       = get_naverpay_item_image_url($it_id);
-    $quantity    = get_naverpay_item_stock($it_id);
-    $ca_name     = '';
-    $ca_name2    = '';
-    $ca_name3    = '';
-    $returnInfo  = get_naverpay_return_info($it['it_seller']);
-    $option      = get_naverpay_item_option($it_id, $it['it_option_subject']);
+        $id          = $it['it_id'];
+        $name        = $it['it_name'];
+        $description = $it['it_basic'];
+        $price       = get_price($it);
+        $image       = get_naverpay_item_image_url($it_id);
+        $quantity    = get_naverpay_item_stock($it_id);
+        $ca_name     = '';
+        $ca_name2    = '';
+        $ca_name3    = '';
+        $returnInfo  = get_naverpay_return_info($it['it_seller']);
+        $option      = get_naverpay_item_option($it_id, $it['it_option_subject']);
 
-    if($it['ca_id']) {
-        $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id']}' ");
-        $ca_name = $cat['ca_name'];
+        if ($it['ca_id']) {
+            $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id']}' ");
+            $ca_name = $cat['ca_name'];
+        }
+        if ($it['ca_id2']) {
+            $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id2']}' ");
+            $ca_name2 = $cat['ca_name'];
+        }
+        if ($it['ca_id3']) {
+            $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id3']}' ");
+            $ca_name3 = $cat['ca_name'];
+        }
+    ?>
+        <item id="<?php echo $id; ?>">
+            <?php if ($it['ec_mall_pid']) { ?>
+                <mall_pid>
+                    <![CDATA[<?php echo $it['ec_mall_pid']; ?>]]>
+                </mall_pid>
+            <?php } ?>
+            <name>
+                <![CDATA[<?php echo $name; ?>]]>
+            </name>
+            <url><?php echo shop_item_url($it_id); ?></url>
+            <description>
+                <![CDATA[<?php echo $description; ?>]]>
+            </description>
+            <image><?php echo $image; ?></image>
+            <thumb><?php echo $image; ?></thumb>
+            <price><?php echo $price; ?></price>
+            <quantity><?php echo $quantity; ?></quantity>
+            <category>
+                <first id="MJ01">
+                    <![CDATA[<?php echo $ca_name; ?>]]>
+                </first>
+                <second id="ML01">
+                    <![CDATA[<?php echo $ca_name2; ?>]]>
+                </second>
+                <third id="MN01">
+                    <![CDATA[<?php echo $ca_name3; ?>]]>
+                </third>
+            </category>
+            <?php echo $option; ?>
+            <?php echo $returnInfo; ?>
+        </item>
+    <?php
     }
-    if($it['ca_id2']) {
-        $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id2']}' ");
-        $ca_name2 = $cat['ca_name'];
-    }
-    if($it['ca_id3']) {
-        $cat = sql_fetch(" select ca_name from {$g5['g5_shop_category_table']} where ca_id = '{$it['ca_id3']}' ");
-        $ca_name3 = $cat['ca_name'];
-    }
-?>
-<item id="<?php echo $id; ?>">
-<?php if($it['ec_mall_pid']) { ?>
-<mall_pid><![CDATA[<?php echo $it['ec_mall_pid']; ?>]]></mall_pid>
-<?php } ?>
-<name><![CDATA[<?php echo $name; ?>]]></name>
-<url><?php echo shop_item_url($it_id); ?></url>
-<description><![CDATA[<?php echo $description; ?>]]></description>
-<image><?php echo $image; ?></image>
-<thumb><?php echo $image; ?></thumb>
-<price><?php echo $price; ?></price>
-<quantity><?php echo $quantity; ?></quantity>
-<category>
-<first id="MJ01"><![CDATA[<?php echo $ca_name; ?>]]></first>
-<second id="ML01"><![CDATA[<?php echo $ca_name2; ?>]]></second>
-<third id="MN01"><![CDATA[<?php echo $ca_name3; ?>]]></third>
-</category>
-<?php echo $option; ?>
-<?php echo $returnInfo; ?>
-</item>
-<?php
-}
-echo('</response>');
+    echo ('</response>');


### PR DESCRIPTION
네이버 페이에서 요구하는 naverpay_item.php 페이지의 필수 사항인 ITEM_ID 체크 하는 과정에서의 에러를 수정했습니다.
![image](https://user-images.githubusercontent.com/29420674/128450884-d2c38d2a-ccd3-4aa5-a950-166981564d1a.png)

count 함수의 경우 array 만 평가를 하므로 null을 인자로 받았을때 예외 사항을 발생시킵니다.
`TypeError: count(): Argument #1 ($var) must be of type Countable|array, null given`

그래서 기존의 코드는 아래와 같이 브라우저에 표기가 됩니다.

![image](https://user-images.githubusercontent.com/29420674/128451009-b776ffa7-9c4e-4d79-ba3c-5eefc67dcdb3.png)
---

이를 수정하여 널 일때의 경우도 ITEM_ID 를 체크하는 로직을 타도록 수정했습니다.

**Before**
```
if (count($itemIds) < 1) {
    exit('ITEM_ID 는 필수입니다.');
}
```

**After**
```
if (is_null($itemIds) || count($itemIds) < 1) {
    exit('ITEM_ID 는 필수입니다.');
}
```

**Browser**
![화면 캡처 2021-08-06 122140](https://user-images.githubusercontent.com/29420674/128451133-40a295f8-22c8-45c2-82d0-acbf117ba50f.png)
