### PR TITLE
Fix - 재고관련 자료형 오류 수정

### DIFF
--- a/adm/shop_admin/itemstocklist.php
+++ b/adm/shop_admin/itemstocklist.php
@@ -155,7 +155,7 @@ $listall = '<a href="'.$_SERVER['SCRIPT_NAME'].'" class="ov_listall">전체목�
         $temporary_qty = $row['it_stock_qty'] - $wait_qty;
 
         // 통보수량보다 재고수량이 작을 때
-        $it_stock_qty = number_format($row['it_stock_qty']);
+        $it_stock_qty = number_format((int)$row['it_stock_qty']);
         $it_stock_qty_st = ''; // 스타일 정의
         if($row['it_stock_qty'] <= $row['it_noti_qty']) {
             $it_stock_qty_st = ' sit_stock_qty_alert';
@@ -171,7 +171,7 @@ $listall = '<a href="'.$_SERVER['SCRIPT_NAME'].'" class="ov_listall">전체목�
             <?php echo $row['it_id']; ?>
         </td>
         <td class="td_left"><a href="<?php echo $href; ?>"><?php echo get_it_image($row['it_id'], 50, 50); ?> <?php echo cut_str(stripslashes($row['it_name']), 60, "&#133"); ?></a></td>
-        <td class="td_num<?php echo $it_stock_qty_st; ?>"><?php echo (int)$it_stock_qty; ?></td>
+        <td class="td_num<?php echo $it_stock_qty_st; ?>"><?php echo $it_stock_qty; ?></td>
         <td class="td_num"><?php echo number_format((float)$wait_qty); ?></td>
         <td class="td_num"><?php echo number_format((float)$temporary_qty); ?></td>
         <td class="td_num">

--- a/shop/cartupdate.php
+++ b/shop/cartupdate.php
@@ -32,7 +32,7 @@ if ($member['mb_level'] < $default['de_level_sell'])
 {
     alert('상품을 구입할 수 있는 권한이 없습니다.');
 }
-
+// 장바구니 > 구매
 if($act == "buy")
 {
     if(!count($post_ct_chk))
@@ -74,9 +74,7 @@ if($act == "buy")
                             and ct_status = '쇼핑'
                             and ct_select = '1' ";
                 $sum = sql_fetch($sql);
-                // $sum['cnt'] 가 null 일때 재고 반영이 제대로 안되는 오류 수정 (그누위즈님,210614)
-                // $sum_qty = $sum['cnt'];
-                $sum_qty = is_int($sum['cnt']) ? $sum['cnt'] : 0;
+                $sum_qty = (int)$sum['cnt'];
 
                 // 재고 구함
                 $ct_qty = $row['ct_qty'];
@@ -131,9 +129,9 @@ else if ($act == "seldelete") // 선택삭제
             }
         }
     }
-}
-else // 장바구니에 담기
-{
+// 장바구니에 담기
+// 바로구매, 위시리스트 구매 - sw_direct 1
+} else {
     $count = count($post_it_ids);
     if ($count < 1)
         alert('장바구니에 담을 상품을 선택하여 주십시오.');
@@ -245,10 +243,10 @@ else // 장바구니에 담기
                             and ct_status = '쇼핑'
                             and ct_select = '1' ";
                 $row = sql_fetch($sql);
-                $sum_qty = $row['cnt'];
+                $sum_qty = (int)$row['cnt'];
 
                 // 재고 구함
-                $ct_qty = isset($_POST['ct_qty'][$it_id][$k]) ? (int) $_POST['ct_qty'][$it_id][$k] : 0;
+                $ct_qty = isset($_POST['ct_qty'][$it_id][$k]) ? (int)$_POST['ct_qty'][$it_id][$k] : 0;
                 if(!$io_id)
                     $it_stock_qty = get_it_stock_qty($it_id);
                 else
@@ -317,7 +315,7 @@ else // 장바구니에 담기
             $row2 = sql_fetch($sql2);
             if(isset($row2['ct_id']) && $row2['ct_id']) {
                 // 재고체크
-                $tmp_ct_qty = $row2['ct_qty'];
+                $tmp_ct_qty = (int)$row2['ct_qty'];
                 if(!$io_id)
                     $tmp_it_stock_qty = get_it_stock_qty($it_id);
                 else


### PR DESCRIPTION
**1. number_format 출력 이후 int형 선언으로 인해 재고 출력 오류**
![재고오류](https://user-images.githubusercontent.com/57935683/182341419-8a3089a8-daf4-407a-8e3f-7464b328993c.PNG)

**2. is_int($sum['cnt']) 결과가 항상 false로 리턴되는 오류**
- 데이터베이스에서 조회 후 출력되는 결과 값은 **String** 형식이기 때문에 정수형을 체크하는 **is_int는 항상 false로 리턴**된다.

**3. is_int함수가 특정부분에만 적용된 오류**
- 위의 2번과 함께 수정