### PR TITLE
debugbar 쿼리 오류 표시 추가 및 G5_COLLECT_QUERY 설정 추가

### DIFF
--- a/config.php
+++ b/config.php
@@ -28,6 +28,7 @@ define('G5_HTTPS_DOMAIN', '');
 
 // 그누보드 디버그바 설정입니다, 실제 서버운영시 false 로 설정해 주세요.
 define('G5_DEBUG', false);
+define('G5_COLLECT_QUERY', false);
 
 // Set Database table default engine is Database default_storage_engine, If you want to use MyISAM or InnoDB, change to MyISAM or InnoDB.
 // DB에 테이블 생성 시 테이블의 기본 스토리지 엔진을 설정할 수 있습니다.

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -1623,7 +1623,7 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
 
     $is_debug = get_permission_debug_show();
     
-    $start_time = $is_debug ? get_microtime() : 0;
+    $start_time = ($is_debug || G5_COLLECT_QUERY) ? get_microtime() : 0;
 
     if(function_exists('mysqli_query') && G5_MYSQLI_USE) {
         if ($error) {
@@ -1643,18 +1643,68 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
         }
     }
 
-    $end_time = $is_debug ? get_microtime() : 0;
+    $end_time = ($is_debug || G5_COLLECT_QUERY) ? get_microtime() : 0;
 
-    if($result && $is_debug) {
-        // 여기에 실행한 sql문을 화면에 표시하는 로직 넣기
+    $error = null;
+    if ($is_debug || G5_COLLECT_QUERY) {
+        if(function_exists('mysqli_error') && G5_MYSQLI_USE) {
+            $error = array(
+                'error_code' => mysqli_errno($g5['connect_db']),
+                'error_message' => mysqli_error($g5['connect_db']),
+            );
+        } else {
+            $error = array(
+                'error_code' => mysql_errno($g5['connect_db']),
+                'error_message' => mysql_error($g5['connect_db']),
+            );
+        }
+
+        $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $source = array();
+        $found = false;
+
+        foreach ($stack as $index => $trace) {
+            if ($trace['function'] === 'sql_query') {
+                $found = true;
+            }
+            if (isset($stack[$index + 1]) && $stack[$index + 1]['function'] === 'sql_fetch') {
+                continue;
+            }
+
+            if ($found) {
+                $trace['file'] = str_replace($_SERVER['DOCUMENT_ROOT'], '', $trace['file']);
+                $source['file'] = $trace['file'];
+                $source['line'] = $trace['line'];
+
+                $parent = (isset($stack[$index + 1])) ? $stack[$index + 1] : array();
+                if (isset($parent['function'])) {
+                    if (in_array($trace['function'], array('sql_query', 'sql_fetch')) && (isset($parent['function']) && !in_array($parent['function'], array('sql_fetch', 'include', 'include_once', 'require', 'require_once')))) {
+                        if (isset($parent['class']) && $parent['class']) {
+                            $source['class'] = $parent['class'];
+                            $source['function'] = $parent['function'];
+                            $source['type'] = $parent['type'];
+                        } else {
+                            $source['function'] = $parent['function'];
+                        }
+                    }
+                }
+                break;
+            }
+        }
+
         $g5_debug['sql'][] = array(
             'sql' => $sql,
+            'result' => $result,
+            'success' => !!$result,
+            'source' => $source,
+            'error_code' => $error['error_code'],
+            'error_message' => $error['error_message'],
             'start_time' => $start_time,
             'end_time' => $end_time,
-            );
+        );
     }
 
-    run_event('sql_query_after', $result, $sql, $start_time, $end_time);
+    run_event('sql_query_after', $result, $sql, $start_time, $end_time, $error);
 
     return $result;
 }

--- a/plugin/debugbar/debugbar.php
+++ b/plugin/debugbar/debugbar.php
@@ -54,7 +54,27 @@ add_stylesheet('<link rel="stylesheet" href="'.G5_PLUGIN_URL.'/debugbar/style.cs
                 ?>
                 <tr>
                     <td scope="row" data-label="실행순서"><?php echo $key; ?></td>
-                    <td class="left" data-label="쿼리문"><?php echo $query['sql']; ?></td>
+                    <td class="left" data-label="쿼리문">
+                        <?php
+                            if(isset($query['source']['class'])) {
+                                $function = "{$query['source']['class']}{$query['source']['type']}{$query['source']['function']}()";
+                            } else if (isset($query['source']['function'])) {
+                                $function = "{$query['source']['function']}()";
+                            } else {
+                                $function = null;
+                            }
+                        ?>
+                        <p class="query_source">
+                            <em><?php echo "{$query['source']['file']}:{$query['source']['line']}" ?></em><br>
+                            <?php if($function) { echo "<em>{$function}</em><br>"; } ?>
+                        </p>
+                        <?php
+                        echo "<p class=\"query_sql\">{$query['sql']}</p>";
+                        if(!$query['success']) {
+                            echo '<p class="query_error_message">오류: [' . $query['error_code'] . '] ' . $query['error_message'] . '</p>';
+                        }
+                        ?>
+                    </td>
                     <td data-label="실행시간"><?php echo $show_excuted_time.' ms'; ?></td>
                 </tr>
                 <?php } ?>

--- a/plugin/debugbar/style.css
+++ b/plugin/debugbar/style.css
@@ -23,12 +23,14 @@
 .debug_table{border:1px solid #ccc;border-collapse:collapse;margin:0;padding:0;width:100%}
 .debug_table caption{display:none}
 .debug_table tr{background:#f8f8f8;border:1px solid #ddd;padding:.35em}
-.debug_table th,.debug_table td{padding:.625em;text-align:center}
+.debug_table th,.debug_table td{padding:.625em;text-align:center;white-space:nowrap;}
 .debug_table tbody tr:hover td{background:#c7d4dd!important}
 .debug_table tbody tr:nth-child(even){background-color:#fff}
-.debug_table td.left{text-align:left}
+.debug_table td.left{text-align:left;font-family:monospace;white-space:initial}
 .debug_table th{font-size:.85em;letter-spacing:.1em;text-transform:uppercase}
 .debug_table td img{text-align:center}
+.debug_table .query_sql {font-weight:bold;margin:.5em 0}
+.debug_table .query_error_message {color:red;margin:.5em 0}
 
 .debug_table.hook_table th, .debug_table.hook_table td {text-align:left;border:1px solid #ddd;}
 .hook_table .hook_count{margin-left:3px;font-size:0.9em;color:#7cbc0a}


### PR DESCRIPTION
https://github.com/gnuboard/gnuboard5/issues/210 이슈에서 제안했던 개선안을 적용해봤습니다.

이 제안은 아래 사항을 담고있습니다.
- debugbar에 현재 성공한 쿼리 목록만 보여지는 것을 실패한 쿼리와 오류 메시지 표시하여 디버깅 툴에 부합하도록 개선
- debugbar에 쿼리가 실행된 파일 및 함수에 대한 정보 출력 추가
- 디버그 모드(`G5_DEBUG`)를 켜지 않아도 `G5_COLLECT_QUERY` 상수 설정 추가하여 쿼리 목록을 수집할 수 있도록 함
  - slow log 및 오류를 수집하여 기록을 남기거나 알림을 제공하는 서드파티 기능 개발 가능성 제공

debugbar에 오류 메시지 출력이 추가와 약간의 스타일 변경이 적용된 화면입니다.
(쿼리 목록은 한 화면에 담기위해 일부 요소를 가렸을 뿐 정상 출력됨)
<img width="787" alt="debugbar1" src="https://user-images.githubusercontent.com/112419763/204162863-ce24e27d-fadd-4ae3-af4d-3461c8a3a82e.png">



PHP 5.2에서 동작여부를 확인했습니다.