### PR TITLE
사용자 정의 설정 파일을 사용하도록 개선

### DIFF
--- a/config.php
+++ b/config.php
@@ -8,6 +8,10 @@
 define('_GNUBOARD_', true);
 
 include_once($g5_path['path'].'/version.php');   // 설정 파일
+// 사용자 커스텀 설정 파일
+if (file_exists($g5_path['path'] . '/config.custom.php')) {
+    include_once($g5_path['path'] . '/config.custom.php');
+}
 
 // 기본 시간대 설정
 date_default_timezone_set("Asia/Seoul");
@@ -27,8 +31,12 @@ define('G5_DOMAIN', '');
 define('G5_HTTPS_DOMAIN', '');
 
 // 그누보드 디버그바 설정입니다, 실제 서버운영시 false 로 설정해 주세요.
-define('G5_DEBUG', false);
-define('G5_COLLECT_QUERY', false);
+if (!defined('G5_DEBUG')) {
+    define('G5_DEBUG', false);
+}
+if (!defined('G5_COLLECT_QUERY')) {
+    define('G5_COLLECT_QUERY', false);
+}
 
 // Set Database table default engine is Database default_storage_engine, If you want to use MyISAM or InnoDB, change to MyISAM or InnoDB.
 // DB에 테이블 생성 시 테이블의 기본 스토리지 엔진을 설정할 수 있습니다.


### PR DESCRIPTION
https://github.com/gnuboard/gnuboard5/issues/210#issuecomment-1327035366 이슈에서 config.custom.php 파일에 관련한 내용을 반영한 코드입니다.

`/config.custom.php` 파일이 존재하면 include하여 코어의 설정 파일을 수정하지 않고도 설정을 변경할 수 있도록 지원합니다.

현재는 G5_DEBUG, G5_COLLECT_QUERY에 대해서만 적용해봤으나, 좀 더 확대하여 적용하면 좋을 것 같습니다.
제가 보기엔 아래 목록 정도면 되지 않을까 싶긴합니다.

```
G5_DOMAIN
G5_HTTPS_DOMAIN
G5_DB_ENGINE
G5_DB_CHARSET
G5_COOKIE_DOMAIN
G5_DBCONFIG_FILE
G5_ADMIN_DIR
G5_BBS_DIR
G5_CSS_DIR
G5_DATA_DIR
G5_EXTEND_DIR
G5_IMG_DIR
G5_JS_DIR
G5_LIB_DIR
G5_PLUGIN_DIR
G5_SKIN_DIR
G5_EDITOR_DIR
G5_MOBILE_DIR
G5_OKNAME_DIR
G5_KCPCERT_DIR
G5_INICERT_DIR
G5_LGXPAY_DIR
G5_SNS_DIR
G5_SYNDI_DIR
G5_PHPMAILER_DIR
G5_SESSION_DIR
G5_THEME_DIR
G5_GROUP_DIR
G5_CONTENT_DIR
G5_SET_DEVICE
G5_USE_MOBILE
G5_USE_CACHE
G5_SERVER_TIME
G5_SEO_TITLE_WORD_CUT
G5_DIR_PERMISSION
G5_FILE_PERMISSION
G5_MOBILE_AGENT
G5_SMTP
G5_SMTP_PORT
G5_DISPLAY_SQL_ERROR
G5_LINK_COUNT
G5_THUMB_JPG_QUALITY
G5_THUMB_PNG_COMPRESS
G5_IS_MOBILE_DHTML_USE
G5_MYSQLI_USE
G5_BROWSCAP_USE
G5_VISIT_BROWSCAP_USE
G5_IP_DISPLAY
G5_POSTCODE_JS
```

- G5_URL ,G5_PATH, G5_ADMIN_URL ~ G5_PHPMAILER_PATH 같은 것들은 G5_ADMIN_DIR 등의 폴더명을 지정한 상수들을 기반으로 자동으로 만들어지는 것들이고 설정이라기보다는 변조를 막기위해 상수를 사용했다고 보는게 맞을 것같고
- G5_TIME_YMDHIS ~ G5_SPECIAL 이것들은 변경하면 안되는 것들이고
- G5_STRING_ENCRYPT_FUNCTION 이런 함호화 관련된 것들은... 조금 애매하지만 그냥 두는게 나을 것 같기도 합니다.



