### PR TITLE
#212 PR에서 DB 커넥션 지정 오류 수정 & sql_query_after 이벤트에 누락된 $source 파라메터 추가

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -1648,21 +1648,21 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
     $end_time = ($is_debug || G5_COLLECT_QUERY) ? get_microtime() : 0;
 
     $error = null;
+    $source = array();
     if ($is_debug || G5_COLLECT_QUERY) {
         if(function_exists('mysqli_error') && G5_MYSQLI_USE) {
             $error = array(
-                'error_code' => mysqli_errno($g5['connect_db']),
-                'error_message' => mysqli_error($g5['connect_db']),
+                'error_code' => mysqli_errno($link),
+                'error_message' => mysqli_error($link),
             );
         } else {
             $error = array(
-                'error_code' => mysql_errno($g5['connect_db']),
-                'error_message' => mysql_error($g5['connect_db']),
+                'error_code' => mysql_errno($link),
+                'error_message' => mysql_error($link),
             );
         }
 
         $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $source = array();
         $found = false;
 
         foreach ($stack as $index => $trace) {
@@ -1706,7 +1706,7 @@ function sql_query($sql, $error=G5_DISPLAY_SQL_ERROR, $link=null)
         );
     }
 
-    run_event('sql_query_after', $result, $sql, $start_time, $end_time, $error);
+    run_event('sql_query_after', $result, $sql, $start_time, $end_time, $error, $source);
 
     return $result;
 }


### PR DESCRIPTION
외부 플러그인에서 구현했던 코드를 옮기다 붙이다보니 실수가 있었습니다.

DB 커넥션 지정의 실수가 있어서 고쳤고 이벤트 리스너에 $source 데이터를 전달하도록 수정했습니다.