### PR TITLE
DB 업그레이드 시 업그레이드 항목을 표시할 수 있도록 Hook 개선

### DIFF
--- a/adm/dbupgrade.php
+++ b/adm/dbupgrade.php
@@ -13,20 +13,20 @@ $is_check = false;
 $upgradedMessage = array();
 
 //소셜 로그인 관련 필드 및 구글 리챕챠 필드 추가
-if(!isset($config['cf_social_login_use'])) {
+if (!isset($config['cf_social_login_use'])) {
     sql_query("ALTER TABLE `{$g5['config_table']}`
-                ADD `cf_social_login_use` tinyint(4) NOT NULL DEFAULT '0' AFTER `cf_googl_shorturl_apikey`,
-                ADD `cf_google_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_twitter_secret`,
-                ADD `cf_google_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_google_clientid`,
-                ADD `cf_naver_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_google_secret`,
-                ADD `cf_naver_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_naver_clientid`,
-                ADD `cf_kakao_rest_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_naver_secret`,
-                ADD `cf_social_servicelist` varchar(255) NOT NULL DEFAULT '' AFTER `cf_social_login_use`,
-                ADD `cf_payco_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_social_servicelist`,
-                ADD `cf_payco_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_payco_clientid`,
-                ADD `cf_captcha` varchar(100) NOT NULL DEFAULT '' AFTER `cf_kakao_js_apikey`,
-                ADD `cf_recaptcha_site_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_captcha`,
-                ADD `cf_recaptcha_secret_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_recaptcha_site_key`
+        ADD `cf_social_login_use` tinyint(4) NOT NULL DEFAULT '0' AFTER `cf_googl_shorturl_apikey`,
+        ADD `cf_google_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_twitter_secret`,
+        ADD `cf_google_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_google_clientid`,
+        ADD `cf_naver_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_google_secret`,
+        ADD `cf_naver_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_naver_clientid`,
+        ADD `cf_kakao_rest_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_naver_secret`,
+        ADD `cf_social_servicelist` varchar(255) NOT NULL DEFAULT '' AFTER `cf_social_login_use`,
+        ADD `cf_payco_clientid` varchar(100) NOT NULL DEFAULT '' AFTER `cf_social_servicelist`,
+        ADD `cf_payco_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_payco_clientid`,
+        ADD `cf_captcha` varchar(100) NOT NULL DEFAULT '' AFTER `cf_kakao_js_apikey`,
+        ADD `cf_recaptcha_site_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_captcha`,
+        ADD `cf_recaptcha_secret_key` varchar(100) NOT NULL DEFAULT '' AFTER `cf_recaptcha_site_key`
     ", true);
 
     $is_check = true;
@@ -34,9 +34,9 @@ if(!isset($config['cf_social_login_use'])) {
 }
 
 //소셜 로그인 관련 필드 카카오 클라이언트 시크릿 추가
-if(!isset($config['cf_kakao_client_secret'])) {
+if (!isset($config['cf_kakao_client_secret'])) {
     sql_query("ALTER TABLE `{$g5['config_table']}`
-                ADD `cf_kakao_client_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_kakao_rest_key`
+        ADD `cf_kakao_client_secret` varchar(100) NOT NULL DEFAULT '' AFTER `cf_kakao_rest_key`
     ", true);
 
     $is_check = true;
@@ -44,11 +44,11 @@ if(!isset($config['cf_kakao_client_secret'])) {
 }
 
 // 회원 이미지 관련 필드 추가
-if(!isset($config['cf_member_img_size'])) {
+if (!isset($config['cf_member_img_size'])) {
     sql_query("ALTER TABLE `{$g5['config_table']}`
-                ADD `cf_member_img_size` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_icon_height`,
-                ADD `cf_member_img_width` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_img_size`,
-                ADD `cf_member_img_height` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_img_width`
+        ADD `cf_member_img_size` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_icon_height`,
+        ADD `cf_member_img_width` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_img_size`,
+        ADD `cf_member_img_height` int(11) NOT NULL DEFAULT '0' AFTER `cf_member_img_width`
     ", true);
 
     $sql = " update {$g5['config_table']} set cf_member_img_size = 50000, cf_member_img_width = 60, cf_member_img_height = 60 ";
@@ -59,23 +59,23 @@ if(!isset($config['cf_member_img_size'])) {
 }
 
 // 소셜 로그인 관리 테이블 없을 경우 생성
-if( isset($g5['social_profile_table']) && !sql_query(" DESC {$g5['social_profile_table']} ", false)) {
+if (isset($g5['social_profile_table']) && !sql_query(" DESC {$g5['social_profile_table']} ", false)) {
     sql_query(" CREATE TABLE IF NOT EXISTS `{$g5['social_profile_table']}` (
-                  `mp_no` int(11) NOT NULL AUTO_INCREMENT,
-                  `mb_id` varchar(255) NOT NULL DEFAULT '',
-                  `provider` varchar(50) NOT NULL DEFAULT '',
-                  `object_sha` varchar(45) NOT NULL DEFAULT '',
-                  `identifier` varchar(255) NOT NULL DEFAULT '',
-                  `profileurl` varchar(255) NOT NULL DEFAULT '',
-                  `photourl` varchar(255) NOT NULL DEFAULT '',
-                  `displayname` varchar(150) NOT NULL DEFAULT '',
-                  `description` varchar(255) NOT NULL DEFAULT '',
-                  `mp_register_day` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-                  `mp_latest_day` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-                  UNIQUE KEY `mp_no` (`mp_no`),
-                  KEY `mb_id` (`mb_id`),
-                  KEY `provider` (`provider`)
-                ) ", true);
+        `mp_no` int(11) NOT NULL AUTO_INCREMENT,
+        `mb_id` varchar(255) NOT NULL DEFAULT '',
+        `provider` varchar(50) NOT NULL DEFAULT '',
+        `object_sha` varchar(45) NOT NULL DEFAULT '',
+        `identifier` varchar(255) NOT NULL DEFAULT '',
+        `profileurl` varchar(255) NOT NULL DEFAULT '',
+        `photourl` varchar(255) NOT NULL DEFAULT '',
+        `displayname` varchar(150) NOT NULL DEFAULT '',
+        `description` varchar(255) NOT NULL DEFAULT '',
+        `mp_register_day` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+        `mp_latest_day` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+        UNIQUE KEY `mp_no` (`mp_no`),
+        KEY `mb_id` (`mb_id`),
+        KEY `provider` (`provider`)
+    )", true);
 
     $is_check = true;
     $upgradedMessage[] = '[G5] 소셜 로그인 관리 테이블 없을 경우 생성';
@@ -90,11 +90,11 @@ while ($row = sql_fetch_array($result)) {
 
     $sql = " SHOW COLUMNS FROM {$write_table} LIKE 'wr_seo_title' ";
     $row = sql_fetch($sql);
-    
-    if( !$row ){
+
+    if (!$row) {
         sql_query("ALTER TABLE `{$write_table}`
-                    ADD `wr_seo_title` varchar(200) NOT NULL DEFAULT '' AFTER `wr_content`,
-                    ADD INDEX `wr_seo_title` (`wr_seo_title`);
+            ADD `wr_seo_title` varchar(200) NOT NULL DEFAULT '' AFTER `wr_content`,
+            ADD INDEX `wr_seo_title` (`wr_seo_title`);
         ", false);
 
         $is_check = true;
@@ -106,10 +106,10 @@ while ($row = sql_fetch_array($result)) {
 $sql = " SHOW COLUMNS FROM `{$g5['content_table']}` LIKE 'co_seo_title' ";
 $row = sql_fetch($sql);
 
-if( !$row ){
+if (!$row) {
     sql_query("ALTER TABLE `{$g5['content_table']}`
-                ADD `co_seo_title` varchar(200) NOT NULL DEFAULT '' AFTER `co_content`,
-                ADD INDEX `co_seo_title` (`co_seo_title`);
+        ADD `co_seo_title` varchar(200) NOT NULL DEFAULT '' AFTER `co_content`,
+        ADD INDEX `co_seo_title` (`co_seo_title`);
     ", false);
 
     $is_check = true;
@@ -120,16 +120,14 @@ $sql = "select * from {$g5['content_table']} limit 100 ";
 $result = sql_query($sql);
 
 while ($row = sql_fetch_array($result)) {
-
-    if( ! $row['co_seo_title']){
-        
+    if (!$row['co_seo_title']) {
         $co_seo_title = exist_seo_title_recursive('content', generate_seo_title($row['co_subject']), $g5['content_table'], $row['co_id']);
-        
-        $sql = " update {$g5['content_table']}
-                    set co_seo_title = '$co_seo_title'
-                  where co_id = '{$row['co_id']}' ";
-        sql_query($sql);
 
+        $sql = " UPDATE {$g5['content_table']}
+            SET co_seo_title = '{$co_seo_title}'
+            WHERE co_id = '{$row['co_id']}'
+        ";
+        sql_query($sql);
     }
 }
 
@@ -137,12 +135,12 @@ while ($row = sql_fetch_array($result)) {
 $sql = " SHOW COLUMNS FROM `{$g5['memo_table']}` LIKE 'me_send_id' ";
 $row = sql_fetch($sql);
 
-if( !$row ){
+if (!$row) {
     sql_query("ALTER TABLE `{$g5['memo_table']}`
-                ADD `me_send_id` INT(11) NOT NULL DEFAULT '0',
-                ADD `me_type` ENUM('send','recv') NOT NULL DEFAULT 'recv',
-                ADD `me_send_ip` VARCHAR(100) NOT NULL DEFAULT '',
-                CHANGE COLUMN `me_id` `me_id` INT(11) NOT NULL AUTO_INCREMENT;
+        ADD `me_send_id` INT(11) NOT NULL DEFAULT '0',
+        ADD `me_type` ENUM('send','recv') NOT NULL DEFAULT 'recv',
+        ADD `me_send_ip` VARCHAR(100) NOT NULL DEFAULT '',
+        CHANGE COLUMN `me_id` `me_id` INT(11) NOT NULL AUTO_INCREMENT;
     ", false);
 
     $is_check = true;
@@ -150,29 +148,32 @@ if( !$row ){
 }
 
 // 읽지 않은 메모 수 칼럼
-if(!isset($member['mb_memo_cnt'])) {
+if (!isset($member['mb_memo_cnt'])) {
     sql_query(" ALTER TABLE `{$g5['member_table']}`
-                ADD `mb_memo_cnt` int(11) NOT NULL DEFAULT '0' AFTER `mb_memo_call`", true);
+        ADD `mb_memo_cnt` int(11) NOT NULL DEFAULT '0' AFTER `mb_memo_call`
+    ", true);
 
     $is_check = true;
     $upgradedMessage[] = '[G5] 메모 읽지 않은 메모 수 칼럼 추가';
 }
 
 // 스크랩 읽은 수 추가
-if(!isset($member['mb_scrap_cnt'])) {
+if (!isset($member['mb_scrap_cnt'])) {
     sql_query(" ALTER TABLE `{$g5['member_table']}`
-                ADD `mb_scrap_cnt` int(11) NOT NULL DEFAULT '0' AFTER `mb_memo_cnt`", true);
+        ADD `mb_scrap_cnt` int(11) NOT NULL DEFAULT '0' AFTER `mb_memo_cnt`
+    ", true);
 
-	$is_check = true;
+    $is_check = true;
     $upgradedMessage[] = '[G5] 스크랩 읽은 수 추가';
 }
 
 // 짧은 URL 주소를 사용 여부 필드 추가
 if (!isset($config['cf_bbs_rewrite'])) {
     sql_query(" ALTER TABLE `{$g5['config_table']}`
-                    ADD `cf_bbs_rewrite` tinyint(4) NOT NULL DEFAULT '0' AFTER `cf_link_target` ", true);
+        ADD `cf_bbs_rewrite` tinyint(4) NOT NULL DEFAULT '0' AFTER `cf_link_target`
+    ", true);
 
-	$is_check = true;
+    $is_check = true;
     $upgradedMessage[] = '[G5] 짧은 URL 주소를 사용 여부 필드 추가';
 }
 
@@ -181,11 +182,12 @@ if (!isset($config['cf_bbs_rewrite'])) {
 $sql = " SHOW COLUMNS FROM `{$g5['board_file_table']}` LIKE 'bf_fileurl' ";
 $row = sql_fetch($sql);
 
-if( !$row ) {
-    sql_query(" ALTER TABLE `{$g5['board_file_table']}` 
-                ADD COLUMN `bf_fileurl` VARCHAR(255) NOT NULL DEFAULT '' AFTER `bf_content`,
-                ADD COLUMN `bf_thumburl` VARCHAR(255) NOT NULL DEFAULT '' AFTER `bf_fileurl`,
-                ADD COLUMN `bf_storage` VARCHAR(50) NOT NULL DEFAULT '' AFTER `bf_thumburl`", true);
+if (!$row) {
+    sql_query(" ALTER TABLE `{$g5['board_file_table']}`
+        ADD COLUMN `bf_fileurl` VARCHAR(255) NOT NULL DEFAULT '' AFTER `bf_content`,
+        ADD COLUMN `bf_thumburl` VARCHAR(255) NOT NULL DEFAULT '' AFTER `bf_fileurl`,
+        ADD COLUMN `bf_storage` VARCHAR(50) NOT NULL DEFAULT '' AFTER `bf_thumburl`
+    ", true);
 
     $is_check = true;
     $upgradedMessage[] = '[G5] 파일테이블에 추가 칼럼';
@@ -193,26 +195,27 @@ if( !$row ) {
 
 if (defined('G5_USE_SHOP') && G5_USE_SHOP) {
     // 임시저장 테이블이 없을 경우 생성
-    if(!sql_query(" DESC {$g5['g5_shop_post_log_table']} ", false)) {
+    if (!sql_query(" DESC {$g5['g5_shop_post_log_table']} ", false)) {
         sql_query(" CREATE TABLE IF NOT EXISTS `{$g5['g5_shop_post_log_table']}` (
-                    `log_id` int(11) NOT NULL AUTO_INCREMENT,
-                    `oid` bigint(20) unsigned NOT NULL,
-                    `mb_id` varchar(255) NOT NULL DEFAULT '',
-                    `post_data` text NOT NULL,
-                    `ol_code` varchar(255) NOT NULL DEFAULT '',
-                    `ol_msg` text NOT NULL,
-                    `ol_datetime` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-                    `ol_ip` varchar(25) NOT NULL DEFAULT '',
-                    PRIMARY KEY (`log_id`)
-                    ) ENGINE=MyISAM DEFAULT CHARSET=utf8; ", true);
+                `log_id` int(11) NOT NULL AUTO_INCREMENT,
+                `oid` bigint(20) unsigned NOT NULL,
+                `mb_id` varchar(255) NOT NULL DEFAULT '',
+                `post_data` text NOT NULL,
+                `ol_code` varchar(255) NOT NULL DEFAULT '',
+                `ol_msg` text NOT NULL,
+                `ol_datetime` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+                `ol_ip` varchar(25) NOT NULL DEFAULT '',
+                PRIMARY KEY (`log_id`)
+            ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+        ", true);
 
         $is_check = true;
         $upgradedMessage[] = '[G5] 주문서 임시저장 테이블 생성';
     }
 
     $result = sql_query("describe `{$g5['g5_shop_post_log_table']}`");
-    while ($row = sql_fetch_array($result)){
-        if( isset($row['Field']) && $row['Field'] === 'ol_msg' && $row['Type'] === 'varchar(255)' ){
+    while ($row = sql_fetch_array($result)) {
+        if (isset($row['Field']) && $row['Field'] === 'ol_msg' && $row['Type'] === 'varchar(255)') {
             sql_query("ALTER TABLE `{$g5['g5_shop_post_log_table']}` MODIFY ol_msg TEXT NOT NULL;", false);
             sql_query("ALTER TABLE `{$g5['g5_shop_post_log_table']}` DROP PRIMARY KEY;", false);
             sql_query("ALTER TABLE `{$g5['g5_shop_post_log_table']}` ADD `log_id` int(11) NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (`log_id`);", false);
@@ -247,4 +250,4 @@ $db_upgrade_msg = $is_check ? 'DB 업그레이드가 완료되었습니다.' : '
 </div>
 
 <?php
-include_once ('./admin.tail.php');
+include_once('./admin.tail.php');


### PR DESCRIPTION
서드파티에서 DB 업그레이드 메뉴를 통해 마이그레이션 시 메시지 항목을 추가하면 화면에 표시할 수 있도록 함

```php
add_replace('admin_dbupgrade', 'listener', G5_HOOK_DEFAULT_PRIORITY, 2);

function listener($is_check, &$upgradedMessage)
{
    // ... 마이그레이션 실행
   
    // 마이그레이션 항목의 설명 추가
    $upgradedMessage[] = '[myPlugin] ㅇㅇ 컬럼 추가';
    return true;
}
```