### PR TITLE
Hook에 Closure를 리스너로 등록할 수 있도록 개선

### DIFF
--- a/lib/Hook/hook.extends.class.php
+++ b/lib/Hook/hook.extends.class.php
@@ -19,7 +19,7 @@ Class GML_Hook extends Hook {
 
         $args = $this->getArguments($argsNumber, $args);
 
-        if (! ($class && $method) && function_exists($function)) {
+        if (! ($class && $method) && is_callable($function)) {
             return call_user_func_array($function, $args);
         } elseif ($obj = call_user_func(array($class, $this->singleton))) {
             if ($obj !== false) {


### PR DESCRIPTION
Closure는 PHP 5.3에서 추가되었지만 그누보드에서는 현재 Hook 리스너에 클로저를 등록하여 사용할 수가 없습니다.

물론, PHP 5.2에서는 클로저를 사용할 수 없지만 PHP 5.2 환경에서 동작에 영향을 주지 않으면서도 PHP 5.3이상에서 클로저를 사용할 수 있도록 Hook 클래스를 개선했습니다.

기존 동작을 변경하지 않고 `function_exists()` 대신 `is_callable()`로 대체하는 것만으로 개선이 가능합니다.
(`is_callable()` 함수는 PHP 4에서 추가되었습니다.)


PHP 5.2.17 버전과 5.3.29 버전 및 PHP 7 등에서 테스트했습니다.