### PR TITLE
add_replace()에서 $args 값을 1로 변경

### DIFF
--- a/lib/hook.lib.php
+++ b/lib/hook.lib.php
@@ -65,7 +65,7 @@ function run_event($tag, $arg = ''){
     }
 }
 
-function add_replace($tag, $func, $priority=G5_HOOK_DEFAULT_PRIORITY, $args=0){
+function add_replace($tag, $func, $priority=G5_HOOK_DEFAULT_PRIORITY, $args=1){
 
     if( $hook = get_hook_class() ){
         return $hook->addFilter($tag, $func, $priority, $args);


### PR DESCRIPTION
replace hook은 값을 반환해야하므로 항상 최소 1개의 인자를 받아야하지만 기본 값이 0이어서 매번 이를 변경해줘야하는 불편을 해소