### PR TITLE
adm/view.php 파일에서 $sub_menu 등 변수 위치를 변경

### DIFF
--- a/adm/view.php
+++ b/adm/view.php
@@ -16,10 +16,10 @@ if( ! $is_admin ){
 	}
 }
 
-run_event('admin_request_handler_'.$call, $arr_query, $token);
-
 $sub_menu = admin_menu_find_by($call, 'sub_menu');
 $g5['title'] = admin_menu_find_by($call, 'title');
+
+run_event('admin_request_handler_'.$call, $arr_query, $token);
 
 include_once ('./admin.head.php');
 


### PR DESCRIPTION
`$sub_menu`, `$g5['title']` 변수를 생성처리가 `admin_request_handler_*` Event Hook 보다 이후에 실행되어 해당 Hook에서 이를 활용하지 못하는 문제를 해결합니다.