### PR TITLE
리버스 프록시(로드밸런서, 캐시 등) 사용시 문제 해결

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3550,7 +3550,7 @@ function check_url_host($url, $msg='', $return_url=G5_URL, $is_redirect=false)
     // 리버스 프록시(로드밸런서, 캐시, DDoS 완화 서비스 등) 사용 시
     // 도메인 인식 못하여 'url에 타 도메인을 지정할 수 없습니다.' 메시지 발생 해결
     $host = '';
-    $x = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST');
+    $x = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST'); // 맨 처음 항목이 우선권 높음
     for($i = count($x) -1; $i > -1; $i--) {
         $k = $x[$i];
         if (array_key_exists($k, $_SERVER)) {

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3546,7 +3546,18 @@ function check_url_host($url, $msg='', $return_url=G5_URL, $is_redirect=false)
         $url = $replace_url;
     }
     $p = @parse_url(trim($url));
-    $host = preg_replace('/:[0-9]+$/', '', $_SERVER['HTTP_HOST']);
+
+    // 리버스 프록시(로드밸런서, 캐시, DDoS 완화 서비스 등) 사용 시
+    // 도메인 인식 못하여 'url에 타 도메인을 지정할 수 없습니다.' 메시지 발생 해결
+    $host = '';
+    $x = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST');
+    for($i = count($x) -1; $i > -1; $i--) {
+        $k = $x[$i];
+        if (array_key_exists($k, $_SERVER)) {
+            $host = preg_replace('/:[0-9]+$/', '', $_SERVER[$k]);
+        }
+    }
+
     $is_host_check = false;
     
     // url을 urlencode 를 2번이상하면 parse_url 에서 scheme와 host 값을 가져올수 없는 취약점이 존재함


### PR DESCRIPTION
## 패치요약
* 리버스 프록시(CDN, 로드밸런서, 캐시, 프록시 기반 SSL(보안서버) 서비스, DDoS 완화 서비스 등) 사용 시 도메인 인식 못하여 'url에 타 도메인을 지정할 수 없습니다.' 메시지 발생 해결
* 해당 문제는 `config.php`의 `G5_DOMAIN` 및 'G5_HTTPS_DOMAIN`을 올바르게 설정하여도 발생하는 이슈임.

## 참고링크
* https://sir.kr/qa/237732
* https://apachezone.com/free/4827
* https://cineaste.co.kr/bbs/board.php?bo_table=co_free&wr_id=245128