### PR TITLE
게시판 갤러리 스킨에서 추천/비추천 수 표시를 눈에 덜 띄게 수정

### DIFF
--- a/skin/board/gallery/style.css
+++ b/skin/board/gallery/style.css
@@ -79,7 +79,7 @@ box-shadow:inset 0 2px 5px rgb(33, 135, 202)}
 #bo_gall .gall_info .gall_view {display:inline-block;margin-left:10px;color:#777}
 
 #bo_gall .gall_option {position:absolute;top:10px;right:10px}
-#bo_gall .gall_option strong {background:#ffffffbb;padding:2px 5px; border-radius:30px;}
+#bo_gall .gall_option strong {background:#ffffffbb;padding:2px 5px;border-radius:30px;}
 
 /* 게시판 목록 공통 */
 #bo_btn_top {margin:10px 0}


### PR DESCRIPTION
![IMG_6247](https://github.com/gnuboard/gnuboard5/assets/112419763/a90eca24-f504-430a-90ad-78e32aa4b3fd)

추천/비추천 수 표시가 너무 거대해 이미지를 과도하게 가리지 않도록 간소화 함
- 약간의 투명도
- 여백을 줄임
- 쉐도우 제거 (상호작용 요소로 착각하지 않도록)