### PR TITLE
`qa_delete` Event Hook에서 실제 삭제된 ID 목록을 전달하도록 개선

### DIFF
--- a/bbs/qadelete.php
+++ b/bbs/qadelete.php
@@ -56,21 +56,22 @@ for($i=0; $i<$count; $i++) {
     delete_editor_thumbnail($row['qa_content']);
 
     // 답변이 있는 질문글이라면 답변글 삭제
-    if(!$row['qa_type'] && $row['qa_status']) {
-        $row2 = sql_fetch(" select qa_content, qa_file1, qa_file2 from {$g5['qa_content_table']} where qa_parent = '$qa_id' ");
+    if (!$row['qa_type'] && $row['qa_status']) {
+        $answer = sql_fetch(" SELECT qa_id, qa_content, qa_file1, qa_file2 from {$g5['qa_content_table']} where qa_type = 1 AND qa_parent = {$qa_id} ");
         // 첨부파일 삭제
-        for($k=1; $k<=2; $k++) {
-            @unlink(G5_DATA_PATH.'/qa/'.clean_relative_paths($row2['qa_file'.$k]));
+        for ($k = 1; $k <= 2; $k++) {
+            @unlink(G5_DATA_PATH . '/qa/' . clean_relative_paths($answer['qa_file' . $k]));
             // 썸네일삭제
-            if(preg_match("/\.({$config['cf_image_extension']})$/i", $row2['qa_file'.$k])) {
-                delete_qa_thumbnail($row2['qa_file'.$k]);
+            if (preg_match("/\.({$config['cf_image_extension']})$/i", $answer['qa_file' . $k])) {
+                delete_qa_thumbnail($answer['qa_file' . $k]);
             }
         }
 
         // 에디터 썸네일 삭제
-        delete_editor_thumbnail($row2['qa_content']);
+        delete_editor_thumbnail($answer['qa_content']);
 
-        sql_query(" delete from {$g5['qa_content_table']} where qa_type = '1' and qa_parent = '$qa_id' ");
+        // 답변글 삭제
+        sql_query(" DELETE from {$g5['qa_content_table']} where qa_type = 1 and qa_parent = {$qa_id} ");
     }
 
     // 답변글 삭제시 질문글의 상태변경

--- a/bbs/qadelete.php
+++ b/bbs/qadelete.php
@@ -15,6 +15,7 @@ if (!($token && $delete_token === $token))
     alert('토큰 에러로 삭제 불가합니다.');
 
 $tmp_array = array();
+$deleted = array();
 if ($qa_id) // 건별삭제
     $tmp_array[0] = $qa_id;
 else // 일괄삭제
@@ -72,6 +73,7 @@ for($i=0; $i<$count; $i++) {
 
         // 답변글 삭제
         sql_query(" DELETE from {$g5['qa_content_table']} where qa_type = 1 and qa_parent = {$qa_id} ");
+        $deleted[] = (int) $answer['qa_id'];
     }
 
     // 답변글 삭제시 질문글의 상태변경
@@ -81,8 +83,14 @@ for($i=0; $i<$count; $i++) {
 
     // 글삭제
     sql_query(" delete from {$g5['qa_content_table']} where qa_id = '$qa_id' ");
+    $deleted[] = $qa_id;
 }
 
-run_event('qa_delete', $tmp_array);
+/**
+ * QA 글 삭제 후 Event Hook
+ * @var array $tmp_array 삭제 요청된 qa_id 목록. 소유자 확인, 답변글 존재 여부 등의 이유로 실제로 삭제처리가 안 된 ID가 포함될 수 있으며, 삭제처리 되었더라도 답변글은 이 목록에 포함되지 않음
+ * @var array $deleted 답변글을 포함한 삭제가 완료된 qa_id 목록
+ */
+run_event('qa_delete', $tmp_array, $deleted);
 
 goto_url(G5_BBS_URL.'/qalist.php'.preg_replace('/^&amp;/', '?', $qstr));


### PR DESCRIPTION
이는 bcda18cbd5878ee332ca2f223d2ba747e9ca367c 커밋에서 추가된 `qa_delete` Event Hook을 개선하기 위함입니다.

`$tmp_array` 목록은 삭제를 요청한 목록이지만 작성자, 답글 등의 이유로 실제 삭제되지 않을 수 있음.
이로 인해 실제 삭제처리가 완료되지 않은 `qa_id` 목록이 전달될 수 있으므로, 삭제된 것으로 오인하여 처리 시 데이터 손실 문제가 발생할 수 있음

이를 방지하기 위해 호환성을 유지하며 두번째 `$deleted` 인자로 답변글을 포함한 실제로 삭제 처리된 목록만을 넘겨주도록 개선 함.


