### PR TITLE
영카트 상품 복사 후 `shop_admin_itemcopy` Event Hook 추가

### DIFF
--- a/adm/shop_admin/itemcopyupdate.php
+++ b/adm/shop_admin/itemcopyupdate.php
@@ -53,7 +53,7 @@ $opt_sql = " insert ignore into {$g5['g5_shop_item_option_table']} ( io_id, io_t
 sql_query($opt_sql);
 
 // html 에디터로 첨부된 이미지 파일 복사
-$copied_editor_images = [];
+$copied_editor_images = array();
 if($cp['it_explan']) {
     $matchs = get_editor_image($cp['it_explan'], false);
     $count_matchs = (isset($matchs[1]) && is_array($matchs[1])) ? count($matchs[1]) : 0;
@@ -152,7 +152,7 @@ function copy_directory($src_dir, $dest_dir)
 }
 
 // 파일복사
-$copied_item_files = [];
+$copied_item_files = array();
 $dest_path = G5_DATA_PATH.'/item/'.$new_it_id;
 @mkdir($dest_path, G5_DIR_PERMISSION);
 @chmod($dest_path, G5_DIR_PERMISSION);
@@ -169,10 +169,10 @@ for($i=1; $i<=10; $i++) {
         @chmod($dstfile, G5_FILE_PERMISSION);
         $new_img = $new_it_id.'/'.basename($file);
 
-        $copied_item_files[] = [
+        $copied_item_files[] = array(
             'original' => $file,
             'new' => $dstfile,
-        ];
+        );
     }
 
     $sql_img .= $comma." it_img{$i} = '$new_img' ";
@@ -192,13 +192,13 @@ sql_query($sql);
  * @var array $copied_item_files 복사한 파일 목록
  * @var array $copied_editor_images 복사한 에디터 이미지 목록
  */
-run_event('shop_admin_itemcopy', [
+run_event('shop_admin_itemcopy', array(
     'it_id' => (string) $it_id,
     'new_it_id' => (string) $new_it_id,
     'cp' => $cp,
     'copied_item_files' => $copied_item_files,
     'copied_editor_images' => $copied_editor_images
-]);
+));
 
 $qstr = "ca_id=$ca_id&amp;sfl=$sfl&amp;sca=$sca&amp;page=$page&amp;stx=".urlencode($stx);
 

--- a/adm/shop_admin/itemcopyupdate.php
+++ b/adm/shop_admin/itemcopyupdate.php
@@ -53,6 +53,7 @@ $opt_sql = " insert ignore into {$g5['g5_shop_item_option_table']} ( io_id, io_t
 sql_query($opt_sql);
 
 // html 에디터로 첨부된 이미지 파일 복사
+$copied_editor_images = [];
 if($cp['it_explan']) {
     $matchs = get_editor_image($cp['it_explan'], false);
     $count_matchs = (isset($matchs[1]) && is_array($matchs[1])) ? count($matchs[1]) : 0;
@@ -73,7 +74,13 @@ if($cp['it_explan']) {
 
             $newfile = preg_replace("/\.([^\.]+)$/", "_".$new_it_id.".\\1", $matchs[1][$i]);
             $cp['it_explan'] = str_replace($matchs[1][$i], $newfile, $cp['it_explan']);
+
+            $copied_editor_images[] = array(
+                'original' => $srcfile,
+                'new' => $dstfile
+            );
         }
+        
     }
 
     $sql = " update {$g5['g5_shop_item_table']} set it_explan = '".addslashes($cp['it_explan'])."' where it_id = '$new_it_id' ";
@@ -100,6 +107,11 @@ if($cp['it_mobile_explan']) {
 
             $newfile = preg_replace("/\.([^\.]+)$/", "_".$new_it_id.".\\1", $matchs[1][$i]);
             $cp['it_mobile_explan'] = str_replace($matchs[1][$i], $newfile, $cp['it_mobile_explan']);
+
+            $copied_editor_images[] = array(
+                'original' => $srcfile,
+                'new' => $dstfile
+            );
         }
     }
 
@@ -140,6 +152,7 @@ function copy_directory($src_dir, $dest_dir)
 }
 
 // 파일복사
+$copied_item_files = [];
 $dest_path = G5_DATA_PATH.'/item/'.$new_it_id;
 @mkdir($dest_path, G5_DIR_PERMISSION);
 @chmod($dest_path, G5_DIR_PERMISSION);
@@ -155,6 +168,11 @@ for($i=1; $i<=10; $i++) {
         copy($file, $dstfile);
         @chmod($dstfile, G5_FILE_PERMISSION);
         $new_img = $new_it_id.'/'.basename($file);
+
+        $copied_item_files[] = [
+            'original' => $file,
+            'new' => $dstfile,
+        ];
     }
 
     $sql_img .= $comma." it_img{$i} = '$new_img' ";
@@ -165,6 +183,22 @@ $sql = " update {$g5['g5_shop_item_table']}
             set $sql_img
             where it_id = '$new_it_id' ";
 sql_query($sql);
+
+/**
+ * 아이템 복사 처리 후 Event Hook
+ * @var string $it_id 원본 아이템 ID
+ * @var string $new_it_id 복사한 새로운 아이템 ID
+ * @var array $cp 복사한 아이템 정보
+ * @var array $copied_item_files 복사한 파일 목록
+ * @var array $copied_editor_images 복사한 에디터 이미지 목록
+ */
+run_event('shop_admin_itemcopy', [
+    'it_id' => (string) $it_id,
+    'new_it_id' => (string) $new_it_id,
+    'cp' => $cp,
+    'copied_item_files' => $copied_item_files,
+    'copied_editor_images' => $copied_editor_images
+]);
 
 $qstr = "ca_id=$ca_id&amp;sfl=$sfl&amp;sca=$sca&amp;page=$page&amp;stx=".urlencode($stx);
 


### PR DESCRIPTION
영카트에서 상품을 복사한 후에 이벤트 Hook을 추가

Hook Tag: `shop_admin_itemcopy`

전달 인자
* @var string $it_id 원본 아이템 ID
* @var string $new_it_id 복사한 새로운 아이템 ID
* @var array $cp 복사한 아이템 정보
* @var array $copied_item_files 복사한 파일 목록
* @var array $copied_editor_images 복사한 에디터 이미지 목록
