### PR TITLE
Refactor: str_encrypt 클래스의 변수 이름 수정

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3804,7 +3804,7 @@ function check_vaild_callback($callback){
 class str_encrypt
 {
     var $salt;
-    var $lenght;
+    var $length;
 
     function __construct($salt='')
     {


### PR DESCRIPTION
변수 이름 오타($lenght)를 $length로 수정하였습니다.