### PR TITLE
`$wr_id` 전역변수의 값이 잘못된 타입으로 할당되는 문제 고침

### DIFF
--- a/common.php
+++ b/common.php
@@ -484,6 +484,7 @@ if (isset($_REQUEST['w'])) {
     $w = '';
 }
 
+/** @var int $wr_id 게시판 글의 ID */
 if (isset($_REQUEST['wr_id'])) {
     $wr_id = (int)$_REQUEST['wr_id'];
 } else {
@@ -581,27 +582,30 @@ if (isset($_SESSION['ss_mb_id']) && $_SESSION['ss_mb_id']) { // 로그인중이�
 }
 
 
+/** @var array $write 글 데이터 */
 $write = array();
+/** @var string $write_table 게시판 테이블 전체이름 */
 $write_table = '';
 if ($bo_table) {
     $board = get_board_db($bo_table, true);
     if (isset($board['bo_table']) && $board['bo_table']) {
         set_cookie("ck_bo_table", $board['bo_table'], 86400 * 1);
         $gr_id = $board['gr_id'];
-        $write_table = $g5['write_prefix'] . $bo_table; // 게시판 테이블 전체이름
+        // 게시판 테이블 전체이름
+        $write_table = $g5['write_prefix'] . $bo_table; 
 
         if (isset($wr_id) && $wr_id) {
             $write = get_write($write_table, $wr_id);
         } else if (isset($wr_seo_title) && $wr_seo_title) {
             $write = get_content_by_field($write_table, 'bbs', 'wr_seo_title', generate_seo_title($wr_seo_title));
-            if( isset($write['wr_id']) ){
-                $wr_id = $write['wr_id'];
+            if (isset($write['wr_id'])) {
+                $wr_id = (int) $write['wr_id'];
             }
         }
     }
-    
-    // 게시판에서 
-    if (isset($board['bo_select_editor']) && $board['bo_select_editor']){
+
+    // 게시판에서 사용하는 에디터를 설정
+    if (isset($board['bo_select_editor']) && $board['bo_select_editor']) {
         $config['cf_editor'] = $board['bo_select_editor'];
     }
 }


### PR DESCRIPTION
짧은 주소 '글 이름' 주소로 접근할 때 `$wr_id` 전역변수의 값이 `string` 타입으로  잘못 할당되는 문제를 `int` 타입으로 올바르게 바로 잡습니다