### PR TITLE
IP 변경으로 인한 관리페이지 접근 시 접속이 제한되는 문제 해결

### DIFF
--- a/adm/admin.lib.php
+++ b/adm/admin.lib.php
@@ -617,13 +617,12 @@ if (!$member['mb_id']) {
     }
 }
 
-// 관리자의 아이피, 브라우저와 다르다면 세션을 끊고 관리자에게 메일을 보낸다.
-$admin_key = md5($member['mb_datetime'] . get_real_client_ip() . $_SERVER['HTTP_USER_AGENT']);
-if (get_session('ss_mb_key') !== $admin_key) {
-
+// 관리자의 클라이언트를 검증하여 일치하지 않으면 세션을 끊고 관리자에게 메일을 보낸다.
+if (!verify_mb_key($member)) {
     session_destroy();
 
     include_once G5_LIB_PATH . '/mailer.lib.php';
+
     // 메일 알림
     mailer($member['mb_nick'], $member['mb_email'], $member['mb_email'], 'XSS 공격 알림', $_SERVER['REMOTE_ADDR'] . ' 아이피로 XSS 공격이 있었습니다.<br><br>관리자 권한을 탈취하려는 접근이므로 주의하시기 바랍니다.<br><br>해당 아이피는 차단하시고 의심되는 게시물이 있는지 확인하시기 바랍니다.' . G5_URL, 0);
 

--- a/bbs/login_check.php
+++ b/bbs/login_check.php
@@ -71,8 +71,9 @@ if (! (defined('SKIP_SESSION_REGENERATE_ID') && SKIP_SESSION_REGENERATE_ID)) {
 
 // 회원아이디 세션 생성
 set_session('ss_mb_id', $mb['mb_id']);
-// FLASH XSS 공격에 대응하기 위하여 회원의 고유키를 생성해 놓는다. 관리자에서 검사함 - 110106
-set_session('ss_mb_key', md5($mb['mb_datetime'] . get_real_client_ip() . $_SERVER['HTTP_USER_AGENT']));
+// FLASH XSS 공격에 대응하기 위하여 회원의 고유키를 생성해 놓는다. 관리자에서 검사함
+generate_mb_key($mb);
+
 // 회원의 토큰키를 세션에 저장한다. /common.php 에서 해당 회원의 토큰값을 검사한다.
 if(function_exists('update_auth_session_token')) update_auth_session_token($mb['mb_datetime']);
 

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -2256,11 +2256,12 @@ function check_token()
 }
 
 /**
- * 브라우저 검증을 위한 클라이언트 키 반환 또는 재생성
+ * 브라우저 검증을 위한 세션 반환 및 재생성
+ * @param array $member 로그인 된 회원의 정보. 가입일시(mb_datetime)를 반드시 포함해야 한다.
  * @param bool $regenerate true 이면 재생성
  * @return string
  */
-function mb_client_key($regenerate = false)
+function ss_mb_key($member, $regenerate = false)
 {
     $client_key = ($regenerate) ? null : get_cookie('mb_client_key');
 
@@ -2269,21 +2270,23 @@ function mb_client_key($regenerate = false)
         set_cookie('mb_client_key', $client_key, 86400 * 30, '/', G5_COOKIE_DOMAIN);
     }
 
-    return $client_key;
+    $mb_key = md5($member['mb_datetime'] . $client_key) . md5($_SERVER['HTTP_USER_AGENT']);
+
+    return $mb_key;
 }
 
 /**
  * 회원의 클라이언트 검증
+ * @param array $member 로그인 된 회원의 정보. 가입일시(mb_datetime)를 반드시 포함해야 한다.
  * @return bool
  */
 function verify_mb_key($member)
 {
-    $mb_key = md5($member['mb_datetime'] . mb_client_key()) . md5($_SERVER['HTTP_USER_AGENT']);
-
+    $mb_key = ss_mb_key($member);
     $verified = get_session('ss_mb_key') === $mb_key;
 
     if (!$verified) {
-        mb_client_key(true);
+        ss_mb_key($member, true);
     }
 
     return $verified;
@@ -2292,10 +2295,11 @@ function verify_mb_key($member)
 /**
  * 회원의 클라이언트 검증 키 생성
  * 클라이언트 키를 다시 생성하여 생성된 키는 `ss_mb_key` 세션에 저장됨
+ * @param array $member 로그인 된 회원의 정보. 가입일시(mb_datetime)를 반드시 포함해야 한다.
  */
 function generate_mb_key($member)
 {
-    $mb_key = md5($member['mb_datetime'] . mb_client_key(true)) . md5($_SERVER['HTTP_USER_AGENT']);
+    $mb_key = ss_mb_key($member, true);
     set_session('ss_mb_key', $mb_key);
 }
 

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -2267,7 +2267,7 @@ function ss_mb_key($member, $regenerate = false)
 
     if (!$client_key) {
         $client_key = get_random_token_string(16);
-        set_cookie('mb_client_key', $client_key, 86400 * 30, '/', G5_COOKIE_DOMAIN);
+        set_cookie('mb_client_key', $client_key, G5_SERVER_TIME * -1);
     }
 
     $mb_key = md5($member['mb_datetime'] . $client_key) . md5($_SERVER['HTTP_USER_AGENT']);

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -2255,6 +2255,49 @@ function check_token()
     return true;
 }
 
+/**
+ * 브라우저 검증을 위한 클라이언트 키 반환 또는 재생성
+ * @param bool $regenerate true 이면 재생성
+ * @return string
+ */
+function mb_client_key($regenerate = false)
+{
+    $client_key = ($regenerate) ? null : get_cookie('mb_client_key');
+
+    if (!$client_key) {
+        $client_key = get_random_token_string(16);
+        set_cookie('mb_client_key', $client_key, 86400 * 30, '/', G5_COOKIE_DOMAIN);
+    }
+
+    return $client_key;
+}
+
+/**
+ * 회원의 클라이언트 검증
+ * @return bool
+ */
+function verify_mb_key($member)
+{
+    $mb_key = md5($member['mb_datetime'] . mb_client_key()) . md5($_SERVER['HTTP_USER_AGENT']);
+
+    $verified = get_session('ss_mb_key') === $mb_key;
+
+    if (!$verified) {
+        mb_client_key(true);
+    }
+
+    return $verified;
+}
+
+/**
+ * 회원의 클라이언트 검증 키 생성
+ * 클라이언트 키를 다시 생성하여 생성된 키는 `ss_mb_key` 세션에 저장됨
+ */
+function generate_mb_key($member)
+{
+    $mb_key = md5($member['mb_datetime'] . mb_client_key(true)) . md5($_SERVER['HTTP_USER_AGENT']);
+    set_session('ss_mb_key', $mb_key);
+}
 
 // 문자열에 utf8 문자가 들어 있는지 검사하는 함수
 // 코드 : http://in2.php.net/manual/en/function.mb-check-encoding.php#95289


### PR DESCRIPTION
이 변경사항은 관리자 계정이 프록시, 무선 접속 환경(와이파이, 셀룰러)에서 IP가 수시로 변경될 수 있는 환경에서 관리페이지 접근 시 수시로 제한이 적용되는 문제를 해결하기 위함입니다.

## 문제점

관리자 계정이 관리페이지에 접근할 때 `ss_mb_key` 세션으로 검증과정을 거치는데 `ss_mb_key` 세션의 값에 IP가 조합되어 사용되므로 IP가 변경되는 환경이라면 관리페이지 접근에 수시로 제한이 적용됩니다.

또한, IP를 가져올 때 사용하는 `get_real_client_ip()` 함수에서 참조하는 `$_SERVER['HTTP_X_FORWARDED_FOR']`는 헤더를 이용해 쉽게 위조가 가능하므로 관리자의 IP가 노출된다면 방어수단으로 사용하기에 적합하지도 않습니다.

## 해결방안

`ss_mb_key` 세션의 문자열을 생성할 때 IP를 제거하여 문제를 해결할 수 있습니다.

`ss_mb_key` 값은 회원의 가입일시 + IP + 브라우저 UA 문자열이 조합되어 만들어 집니다.
사실상 회원의 가입일시만으로도 위조가 불가능한 hash를 생성할 수 있으나, 접속 세션의 클라이언트 검증이라는 목적을 유지한다면 가입일시와 UA를 유지하고 IP는 제외할 수 있습니다.

이는 본인이 제보했던 #257 이슈에서 세션 고정취약점 해결 및 HttpOnly로 세션 쿠키가 생성되므로 탈취 가능성을 제거했고 또한, #208 이슈에서도 일반 쿠키의 탈취 가능성도 제거했으므로 IP 등을 제거하기에 문제가 없습니다.

다만, #257 이슈에서 세션고정 취약점을 해결할 때 `SKIP_SESSION_REGENERATE_ID` 상수로 세션고정 취약점이 재현될 수 있는 환경이 있을 수 있으므로 클라이언트 검증은 유지하는 것이 나을 것으로 보입니다.

## 해결방안의 적용

위와 같은 문제를 해결하기 위해 IP를 대신하여 클라이언트를 검증할 쿠키를 생성하여 이를 조합에 사용하는 방법으로 문제를 해결하도록 했습니다.

랜덤으로 생성한 문자열을 `mb_client_key` 쿠키를 사용하고 `generate_mb_key()`, `verify_mb_key()` 함수를 이용해 `ss_mb_key` 세션의 Hash 문자열을 생성하고 검증하도록 했습니다.

IP를 제거하여 이 PR의 주요 문제를 해결하고 클라이언트 검증 기능을 유지하도록 했습니다.

```php
// 로그인 세션 생성 시
// bbs/login_check.php
generate_mb_key($mb);

// 검증
// bbs/admin.lib.php
if (!verify_mb_key($member)) {
    session_destroy();
    // ...
}
```