### PR TITLE
관리권한 설정 시 메뉴명(au_menu)의 길이 제한으로 인한 문제 개선

### DIFF
--- a/adm/dbupgrade.php
+++ b/adm/dbupgrade.php
@@ -207,6 +207,18 @@ if (defined('G5_USE_SHOP') && G5_USE_SHOP) {
     }
 }
 
+// auth.au_menu 컬럼 크기 조정
+$sql = " SHOW COLUMNS FROM `{$g5['auth_table']}` LIKE 'au_menu' ";
+$row = sql_fetch($sql);
+if (
+    stripos($row['Type'], 'varchar') !== false
+    && (int) preg_replace('/[^0-9]/', '', $row['Type']) <= 50
+) {
+    sql_query(" ALTER TABLE `{$g5['auth_table']}` CHANGE `au_menu` `au_menu` VARCHAR(50) NOT NULL; ", true);
+
+    $is_check = true;
+}
+
 $is_check = run_replace('admin_dbupgrade', $is_check);
 
 $db_upgrade_msg = $is_check ? 'DB 업그레이드가 완료되었습니다.' : '더 이상 업그레이드 할 내용이 없습니다.<br>현재 DB 업그레이드가 완료된 상태입니다.';

--- a/install/gnuboard5.sql
+++ b/install/gnuboard5.sql
@@ -7,7 +7,7 @@
 DROP TABLE IF EXISTS `g5_auth`;
 CREATE TABLE IF NOT EXISTS `g5_auth` (
   `mb_id` varchar(20) NOT NULL default '',
-  `au_menu` varchar(20) NOT NULL default '',
+  `au_menu` varchar(50) NOT NULL default '',
   `au_auth` set('r','w','d') NOT NULL default '',
   PRIMARY KEY  (`mb_id`,`au_menu`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
`admin_menu` Hook 으로 관리자 메뉴를 추가하고 `/adm/view.php` 파일에서 제공하는 Hook 을 사용해 관리페이지의 메뉴와 페이지를 쉽게 추가할 수 있습니다.

https://sir.kr/g5_plugin/8893

이 플러그인에서 이를 활용한 것처럼 메뉴의 ID와 view.php 를 활용할 때 그누보드가 기본적으로 사용하는 숫자 형태를 벗어나 문자열을 지정할 수 있는데 이 길이가 다소 부족합니다.

`{prefix}_auth.au_menu` 컬럼의 길이를 20에서 50자로 늘리도록 개선하여 관리페이지에 메뉴와 페이지를 쉽게 추가할 수 있는 기능의 사용성을 높이는데 도움이 될 것으로 보입니다.

이 제안의 검토해주시고 반영해주시기 바랍니다.