### PR TITLE
`get_board_db` Hook이 제대로 동작하지 않는 문제 수정

### DIFF
--- a/lib/get_data.lib.php
+++ b/lib/get_data.lib.php
@@ -79,23 +79,22 @@ function get_board_db($bo_table, $is_cache = false)
         return $cache[$key];
     }
 
-    if (!($cache[$key] = run_replace('get_board_db', array(), $bo_table))) {
-        $sql = " SELECT * from {$g5['board_table']} where bo_table = '{$bo_table}' ";
+    $sql = " SELECT * from {$g5['board_table']} where bo_table = '{$bo_table}' ";
 
-        $board = sql_fetch($sql);
+    $board = sql_fetch($sql);
 
-        $board_defaults = array(
-            'bo_table' => '',
-            'bo_skin' => '',
-            'bo_mobile_skin' => '',
-            'bo_upload_count' => 0,
-            'bo_use_dhtml_editor' => '',
-            'bo_subject' => '',
-            'bo_image_width' => 0
-        );
+    $board_defaults = array(
+        'bo_table' => '',
+        'bo_skin' => '',
+        'bo_mobile_skin' => '',
+        'bo_upload_count' => 0,
+        'bo_use_dhtml_editor' => '',
+        'bo_subject' => '',
+        'bo_image_width' => 0
+    );
 
-        $cache[$key] = array_merge($board_defaults, (array) $board);
-    }
+    $cache[$key] = array_merge($board_defaults, (array) $board);
+    $cache[$key] = run_replace('get_board_db', $cache[$key], $bo_table);
 
     return $cache[$key];
 }


### PR DESCRIPTION
`get_board_db()` 함수에서 `get_board_db` Hook이 실행될 때 첫번째 콜백에 항상 빈 배열이 전달되어 Hook이 제대로 동작할 수 없고, 이 `get_board_db()` 함수 내부에서 정적변수로 캐시한 데이터 마저 역시 빈 배열로 대체시켜 cache 도 제대로 동작하지 않는 문제를 수정합니다.

현재는 아래와 같은 문제로 인해 Hook의 활용과 Cache가 제대로 동작하지 않아 DB 조회를 줄이려는 의도가 동작하지 않습니다.

- 콜백에 항상 빈 배열이 전달 됨
- 잘못 처리된 Hook 사용으로 `get_board_db()` 함수 내의 `$cache[$key]` 값을 항상 빈배열로 대체되어 cache가 활용되지 않음