### PR TITLE
dev: docker image build

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,0 +1,4 @@
+# database information
+DB_NAME=g5-dev
+DB_USER=g5-dev
+DB_PASS=password

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,65 @@
+# Git 저장소 설정 파일을 무시하지 않도록 설정
 !.gitignore
+
+# Apache 서버 설정 파일을 무시
 /.htaccess
+
+# 데이터 디렉토리 무시
 data/
+
+# 테스트 디렉토리 무시
 test/
+
+# sirgle 디렉토리 무시
 sirgle/
+
+# 특정 파일 무시
 test.php
+
+# 확장자가 .key인 파일 무시
 *.key
+
+# 확장자가 .sh인 파일 무시
 *.sh
-log
-g5_tree
-cheditor5.*/
-!ckeditor*/
+
+# 로그 디렉토리 무시
 log/
+
+# g5_tree 파일 무시
+g5_tree
+
+# cheditor5으로 시작하는 파일 및 디렉토리 무시
+cheditor5.*/
+
+# ckeditor로 시작하는 파일 및 디렉토리 무시하지 않음
+!ckeditor*/
+
+# 로그 디렉토리 무시
+log/
+
+# g5_tree 디렉토리 무시
 g5_tree/
+
+# Visual Studio Code 설정 디렉토리 무시
 .vscode/
+
+# naver로 시작하고 .html로 끝나는 파일 무시
 naver*.html
+
+# initests01 디렉토리 무시
 initests01/
+
+# SIRsoft000 디렉토리 무시
 SIRsoft000/
+
+# config.php 파일 무시
 config.php
+
+# pma 디렉토리 무시
 pma/
+
+# start.sh 파일은 무시하지 않음
+!start.sh
+
+# .env 파일 무시
+.env

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,149 @@
+ARG NGINX_VERSION=1.25.3
+ARG PHP_VERSION=8.2-fpm-bookworm
+
+FROM nginx:${NGINX_VERSION} as gnuboard-base
+WORKDIR /usr/src/gnuboard
+COPY . .
+RUN chown -R www-data:www-data /usr/src/gnuboard; \
+	mkdir data; \
+	chown -R www-data:www-data data; \
+	chmod -R 1777 data
+RUN find . -mindepth 1 -maxdepth 1 \( -name '.*' ! -name '.' ! -name '..' \) -o \( -name '*.md' -o -name '*.yml' \) -exec bash -c 'echo "Deleting {}"; rm -rf {}' \;
+
+FROM php:${PHP_VERSION} as final
+ENV NGINX_VERSION   1.25.3
+ENV NJS_VERSION     0.8.2
+ENV PKG_RELEASE     1~bookworm
+
+RUN curl -sSLf -o /usr/local/bin/install-php-extensions \
+        https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
+    chmod +x /usr/local/bin/install-php-extensions; \
+        install-php-extensions gd imagick apcu opcache redis pdo_mysql intl exif zip; \
+    set -eux; \
+    # set recommended PHP.ini settings
+    # see https://secure.php.net/manual/en/opcache.installation.php
+	{ \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
+    { \
+    # https://www.php.net/manual/en/errorfunc.constants.php
+		echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR'; \
+		echo 'display_errors = Off'; \
+		echo 'display_startup_errors = Off'; \
+		echo 'log_errors = On'; \
+		echo 'error_log = /dev/stderr'; \
+		echo 'log_errors_max_len = 1024'; \
+		echo 'ignore_repeated_errors = On'; \
+		echo 'ignore_repeated_source = Off'; \
+		echo 'html_errors = Off'; \
+	} > /usr/local/etc/php/conf.d/error-logging.ini
+
+# Nginx Dockerfile source
+# https://github.com/nginxinc/docker-nginx/blob/4bf0763f4977fff7e9648add59e0540088f3ca9f/mainline/debian/Dockerfile
+RUN set -x \
+# create nginx user/group first, to be consistent throughout docker variants
+    && groupadd --system --gid 101 nginx \
+    && useradd --system --gid nginx --no-create-home --home /nonexistent --comment "nginx user" --shell /bin/false --uid 101 nginx \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -y gnupg1 ca-certificates \
+    && \
+    NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
+    NGINX_GPGKEY_PATH=/usr/share/keyrings/nginx-archive-keyring.gpg; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    found=''; \
+    for server in \
+        hkp://keyserver.ubuntu.com:80 \
+        pgp.mit.edu \
+    ; do \
+        echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
+        gpg1 --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
+    done; \
+    test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
+    gpg1 --export "$NGINX_GPGKEY" > "$NGINX_GPGKEY_PATH" ; \
+    rm -rf "$GNUPGHOME"; \
+    apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
+    && dpkgArch="$(dpkg --print-architecture)" \
+    && nginxPackages=" \
+        nginx=${NGINX_VERSION}-${PKG_RELEASE} \
+        nginx-module-xslt=${NGINX_VERSION}-${PKG_RELEASE} \
+        nginx-module-geoip=${NGINX_VERSION}-${PKG_RELEASE} \
+        nginx-module-image-filter=${NGINX_VERSION}-${PKG_RELEASE} \
+        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE} \
+    " \
+    && case "$dpkgArch" in \
+        amd64|arm64) \
+# arches officialy built by upstream
+            echo "deb [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
+            && apt-get update \
+            ;; \
+        *) \
+# we're on an architecture upstream doesn't officially build for
+# let's build binaries from the published source packages
+            echo "deb-src [signed-by=$NGINX_GPGKEY_PATH] https://nginx.org/packages/mainline/debian/ bookworm nginx" >> /etc/apt/sources.list.d/nginx.list \
+            \
+# new directory for storing sources and .deb files
+            && tempDir="$(mktemp -d)" \
+            && chmod 777 "$tempDir" \
+# (777 to ensure APT's "_apt" user can access it too)
+            \
+# save list of currently-installed packages so build dependencies can be cleanly removed later
+            && savedAptMark="$(apt-mark showmanual)" \
+            \
+# build .deb files from upstream's source packages (which are verified by apt-get)
+            && apt-get update \
+            && apt-get build-dep -y $nginxPackages \
+            && ( \
+                cd "$tempDir" \
+                && DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
+                    apt-get source --compile $nginxPackages \
+            ) \
+# we don't remove APT lists here because they get re-downloaded and removed later
+            \
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+            && apt-mark showmanual | xargs apt-mark auto > /dev/null \
+            && { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+            \
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+            && ls -lAFh "$tempDir" \
+            && ( cd "$tempDir" && dpkg-scanpackages . > Packages ) \
+            && grep '^Package: ' "$tempDir/Packages" \
+            && echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+            && apt-get -o Acquire::GzipIndexes=false update \
+            ;; \
+    esac \
+    \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+                        $nginxPackages \
+                        gettext-base \
+                        curl \
+    && apt-get remove --purge --auto-remove -y && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
+    \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+    && if [ -n "$tempDir" ]; then \
+        apt-get purge -y --auto-remove \
+        && rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+    fi \
+# forward request and error logs to docker log collector
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY --from=gnuboard-base /docker-entrypoint.d/ docker-entrypoint.sh  /
+COPY --from=gnuboard-base --chown=www-data:www-data /usr/src/gnuboard /var/www/html
+COPY --from=gnuboard-base /usr/src/gnuboard/start.sh /
+COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+VOLUME /var/www/html
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+CMD ["/start.sh"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+services:
+  gnuboard-g5:
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+    volumes:
+      - gnuboard5-data-dev:/g6/data
+    ports:
+      - "9876:80"
+
+  gnuboard-db:
+    image: mysql:8.0
+    volumes:
+      - db_data:/var/lib/mysql
+      - db_socket:/var/lib/mysqld
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-password}
+      MYSQL_DATABASE: ${DB_NAME:-g5-dev}
+      MYSQL_USER: ${DB_USER:-g5-dev}
+      MYSQL_PASSWORD: ${DB_PASS:-password}
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u root --password=$${DB_ROOT_PASSWORD:-password}
+      interval: 5s
+      retries: 10
+
+volumes:
+  gnuboard5-data-dev:
+  db_data:
+  db_socket:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,70 @@
+upstream gnuboad {
+    server 127.0.0.1:9000;
+    keepalive 2;
+}
+
+server {
+    listen 80;
+    server_name _;
+    server_tokens off;
+    root /var/www/html/;
+    index index.php index.html index.htm;
+    client_max_body_size 64M;
+
+    set_real_ip_from 0.0.0.0/0;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
+    if (!-e $request_filename) {
+        rewrite ^/content/([0-9a-zA-Z_]+)$ /bbs/content.php?co_id=$1&rewrite=1 break;
+        rewrite ^/content/([^/]+)/$ /bbs/content.php?co_seo_title=$1&rewrite=1 break;
+        rewrite ^/rss/([0-9a-zA-Z_]+)$ /bbs/rss.php?bo_table=$1 break;
+        rewrite ^/([0-9a-zA-Z_]+)$ /bbs/board.php?bo_table=$1&rewrite=1 break;
+        rewrite ^/([0-9a-zA-Z_]+)/write$ /bbs/write.php?bo_table=$1&rewrite=1 break;
+        rewrite ^/([0-9a-zA-Z_]+)/([^/]+)/$
+            /bbs/board.php?bo_table=$1&wr_seo_title=$2&rewrite=1
+            break;
+        rewrite ^/([0-9a-zA-Z_]+)/([0-9]+)$
+            /bbs/board.php?bo_table=$1&wr_id=$2&rewrite=1
+            break;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|woff2|eot|mp4|ogg|ogv|webm|webp|zip|swf|map|avif)$ {
+        #add_header Access-Control-Allow-Origin "*";
+        add_header Cache-Control "public, no-transform, max-age=31536000";
+        #add_header Cloudflare-CDN-Cache-Control "public, no-transform, max-age=31536000";
+        access_log off;
+    }
+
+    location ~ \.php$ {
+
+        try_files $uri =404;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PHP_VALUE
+            "
+            memory_limit=256M;
+            max_execution_time=360;
+            max_input_time=30;
+            max_input_vars=2000;
+            post_max_size=64M;
+            upload_max_filesize=32M;
+            date.timezone=Asia/Seoul;
+            display_errors=off;
+            cgi.fix_pathinfo=0;";
+        fastcgi_pass gnuboad;
+        fastcgi_read_timeout 3600;
+        fastcgi_send_timeout 3600;
+        fastcgi_hide_header X-Powered-By;
+    }
+
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+nginx -g "daemon off;" &
+
+php-fpm


### PR DESCRIPTION
수정사항
1. `.gitignore` 주석 추가

추가사항
1. `dev.Dockerfile` php 공식이미지에서 빌드를 시작함
2. `.env-template` 파일 추가 ( env로 이름 변경하고 내용 수정하면 docker-compose-dev.yml에 반영됨)

기타
1. local에서 실행시 gnuboard5에서 `localhost`로 하드 코딩되어있어서 install로 넘어갈때 port병기 필요함.
2. docker buildx build 할때  ARG로 넘겨주면 PHP 및 Nginx 버전 변경가능
3. PHP 확장 모듈은 PHP 이미지의 베이스에 `gd imagick apcu opcache redis pdo_mysql intl exif zip` 만 추가함 (공식 빌드방식과 동일)
4.  짧은 주소를 활성화 함 `nginx.conf` 참고

실행방법
```bash
docker compose -f docker-compose-dev.yml up -d
```