### PR TITLE
게시판에서 회원 아이디로 댓글 검색시 잘못된 결과가 나오는 문제

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -712,7 +712,7 @@ function get_sql_search($search_ca_name, $search_field, $search_text, $search_op
     $tmp = explode(",", trim($search_field));
     $field = explode("||", $tmp[0]);
     $not_comment = "";
-    if (!empty($tmp[1]))
+    if (isset($tmp[1]))
         $not_comment = $tmp[1];
 
     $str .= "(";
@@ -768,8 +768,11 @@ function get_sql_search($search_ca_name, $search_field, $search_text, $search_op
         $op1 = " $search_operator ";
     }
     $str .= " ) ";
-    if ($not_comment)
+    if ($not_comment === '1') {
         $str .= " and wr_is_comment = '0' ";
+    } else if ($not_comment === '0') {
+        $str .= " and wr_is_comment = '1' ";
+    }
 
     return $str;
 }


### PR DESCRIPTION
[증상]
회원 아이디로 댓글 검색을 하면 내가 작성한 댓글이 포함된 게시글만 조회가 되야하는데
내가 작성한 글(작성한 댓글은 없는)과 내가 댓글 단 글이 모두 조회가 됨


[조치]
내가 댓글 단 글만 조회가 되도록 수정함