### PR TITLE
get_selected 숫자만 있는 문자열 허용

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -2454,8 +2454,8 @@ function abs_ip2long($ip='')
 
 function get_selected($field, $value)
 {
-    if( is_int($value) ){
-        return ((int) $field===$value) ? ' selected="selected"' : '';
+    if(is_numeric($value)){
+        return ($field==$value) ? ' selected="selected"' : '';
     }
 
     return ($field===$value) ? ' selected="selected"' : '';


### PR DESCRIPTION
문제 발생 배경

셀렉트 태그 옵션에서 6이 들어있고
$value 에 "6" 일때

is_int "6" 은 false 가 되서 아래로 가고

아래에서 6==="6" 은 틀린값이 되서 계속 일치하지 않게 됩니다.

그래서 사용시에 강제 형변환을 시켜야하는데요.
아래와 같이 변경하면 기존의 호환성을 유지하면서 편리하게됩니다.


-----------------------------------

is_int 대신 is_numeric 을 사용하면 php 7 과 8 의 == 값 평가 변경과 상관없이
숫자들을 비교할 수있게됩니다.

is_numeric 은 문자열속 숫자(numeric), 정수형  true 입니다.

