### PR TITLE
창고재고 없을때 '재고 부족' sound 처리하는 잘못 노출된 span 태그 제거

### DIFF
--- a/adm/shop_admin/itemstocklist.php
+++ b/adm/shop_admin/itemstocklist.php
@@ -159,7 +159,6 @@ $listall = '<a href="'.$_SERVER['SCRIPT_NAME'].'" class="ov_listall">전체목�
         $it_stock_qty_st = ''; // 스타일 정의
         if($row['it_stock_qty'] <= $row['it_noti_qty']) {
             $it_stock_qty_st = ' sit_stock_qty_alert';
-            $it_stock_qty = ''.$it_stock_qty.' !<span class="sound_only"> 재고부족 </span>';
         }
 
         $bg = 'bg'.($i%2);
@@ -171,7 +170,7 @@ $listall = '<a href="'.$_SERVER['SCRIPT_NAME'].'" class="ov_listall">전체목�
             <?php echo $row['it_id']; ?>
         </td>
         <td class="td_left"><a href="<?php echo $href; ?>"><?php echo get_it_image($row['it_id'], 50, 50); ?> <?php echo cut_str(stripslashes($row['it_name']), 60, "&#133"); ?></a></td>
-        <td class="td_num<?php echo $it_stock_qty_st; ?>"><?php echo get_text($it_stock_qty); ?></td>
+        <td class="td_num<?php echo $it_stock_qty_st; ?>"><?php echo $it_stock_qty; ?></td>
         <td class="td_num"><?php echo number_format((float)$wait_qty); ?></td>
         <td class="td_num"><?php echo number_format((float)$temporary_qty); ?></td>
         <td class="td_num">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ea6e781e-949c-4386-a3a1-21b060d28592)
