### PR TITLE
feat: add list.php theme override

### DIFF
--- a/mobile/shop/list.php
+++ b/mobile/shop/list.php
@@ -1,6 +1,16 @@
 <?php
 include_once('./_common.php');
 
+// 테마에 list.php 있으면 include
+if(defined('G5_THEME_MSHOP_PATH')) {
+    $theme_list_file = G5_THEME_MSHOP_PATH.'/list.php';
+    if(is_file($theme_list_file)) {
+        include_once($theme_list_file);
+        return;
+    }
+    unset($theme_list_file);
+}
+
 // 상품 리스트에서 다른 필드로 정렬을 하려면 아래의 배열 코드에서 해당 필드를 추가하세요.
 if( isset($sort) && ! in_array($sort, array('it_name', 'it_sum_qty', 'it_price', 'it_use_avg', 'it_use_cnt', 'it_update_time')) ){
     $sort='';

--- a/shop/list.php
+++ b/shop/list.php
@@ -14,6 +14,16 @@ if (G5_IS_MOBILE) {
     return;
 }
 
+// 테마에 list.php 있으면 include
+if(defined('G5_THEME_SHOP_PATH')) {
+    $theme_list_file = G5_THEME_SHOP_PATH.'/list.php';
+    if(is_file($theme_list_file)) {
+        include_once($theme_list_file);
+        return;
+    }
+    unset($theme_list_file);
+}
+
 $sql = " select * from {$g5['g5_shop_category_table']} where ca_id = '$ca_id' and ca_use = '1'  ";
 $ca = sql_fetch($sql);
 if (! (isset($ca['ca_id']) && $ca['ca_id']))


### PR DESCRIPTION
## 📑 Description
Add theme override support for `shop/list.php` and `mobile/shop/list.php` file.
`shop/list.php`와 `mobile/shop/list.php` 파일의 테마 오버라이드 지원.

## ℹ Additional Information
Includes theme-specific `list.php` if it exists, enabling easier customization without changing core files.
테마 경로에 `list.php`가 있으면 포함하여, 코어를 변경하지 않고 커스터마이징 가능하도록 합니다.