### PR TITLE
:pencil2: feat: 토스페이먼츠 상점관리자 - ‘테스트모드‘ 추가 반영, NHN KCP 상점관리자 주소 변경

### DIFF
--- a/adm/shop_admin/configform.php
+++ b/adm/shop_admin/configform.php
@@ -640,7 +640,7 @@ if(!$default['de_kakaopay_cancelpwd']){
         <tr id="kcp_vbank_url" class="pg_vbank_url">
             <th scope="row">NHN KCP 가상계좌<br>입금통보 URL</th>
             <td>
-                <?php echo help("NHN KCP 가상계좌 사용시 다음 주소를 <strong><a href=\"http://admin.kcp.co.kr\" target=\"_blank\">NHN KCP 관리자</a> &gt; 상점정보관리 &gt; 정보변경 &gt; 공통URL 정보 &gt; 공통URL 변경후</strong>에 넣으셔야 상점에 자동으로 입금 통보됩니다."); ?>
+                <?php echo help("NHN KCP 가상계좌 사용시 다음 주소를 <strong><a href=\"https://partner.kcp.co.kr\" target=\"_blank\">NHN KCP 관리자</a> &gt; 상점정보관리 &gt; 정보변경 &gt; 공통URL 정보 &gt; 공통URL 변경후</strong>에 넣으셔야 상점에 자동으로 입금 통보됩니다."); ?>
                 <?php echo G5_SHOP_URL; ?>/settle_kcp_common.php</td>
         </tr>
         <tr id="inicis_vbank_url" class="pg_vbank_url">
@@ -694,7 +694,7 @@ if(!$default['de_kakaopay_cancelpwd']){
         <tr>
             <th scope="row"><label for="de_easy_pay_use">PG사 간편결제 버튼 사용</label></th>
             <td>
-                <?php echo help("주문서 작성 페이지에 PG사 간편결제(PAYCO, PAYNOW, KPAY) 버튼의 별도 사용 여부를 설정합니다.", 50); ?>
+                <?php echo help("주문서 작성 페이지에 PG사 간편결제(PAYCO, 토스, KPAY...) 버튼의 별도 사용 여부를 설정합니다.", 50); ?>
                 <select id="de_easy_pay_use" name="de_easy_pay_use">
                     <option value="0" <?php echo get_selected($default['de_easy_pay_use'], 0); ?>>노출안함</option>
                     <option value="1" <?php echo get_selected($default['de_easy_pay_use'], 1); ?>>노출함</option>
@@ -1097,8 +1097,7 @@ if(!$default['de_kakaopay_cancelpwd']){
                     <a href="http://testadmin8.kcp.co.kr/" target="_blank" class="btn_frmline">테스트 관리자</a>
                 </div>
                 <div class="scf_cardtest lg_cardtest">
-                    <a href="https://app.tosspayments.com/" target="_blank" class="btn_frmline">실결제 관리자</a>
-                    <a href="https://pgweb.tosspayments.com/tmert" target="_blank" class="btn_frmline">테스트 관리자</a>
+                    <a href="https://app.tosspayments.com/" target="_blank" class="btn_frmline">상점 관리자</a>
                 </div>
                 <div class="scf_cardtest toss_cardtest">
                     <a href="https://app.tosspayments.com/" target="_blank" class="btn_frmline">상점 관리자</a>
@@ -1122,14 +1121,14 @@ if(!$default['de_kakaopay_cancelpwd']){
                         <dt>휴대폰</dt><dd>테스트 지원되지 않음.</dd>
                     </dl>
                     <ul id="kcp_cardtest_tip" class="scf_cardtest_tip_adm scf_cardtest_tip_adm_hide">
-                        <li>테스트결제의 <a href="http://testadmin8.kcp.co.kr/assist/login.LoginAction.do" target="_blank">상점관리자</a> 로그인 정보는 NHN KCP로 문의하시기 바랍니다. (기술지원 1544-8661)</li>
+                        <li>테스트결제의 <a href="https://testpartner.kcp.co.kr/" target="_blank">상점관리자</a> 로그인 정보는 NHN KCP로 문의하시기 바랍니다. (기술지원 1544-8661)</li>
                         <li><b>일반결제</b>의 테스트 사이트코드는 <b>T0000</b> 이며, <b>에스크로 결제</b>의 테스트 사이트코드는 <b>T0007</b> 입니다.</li>
                     </ul>
                     <ul id="lg_cardtest_tip" class="scf_cardtest_tip_adm scf_cardtest_tip_adm_hide">
-                        <li>테스트결제의 <a href="https://pgweb.tosspayments.com/tmert" target="_blank">상점관리자</a> 로그인 정보는 토스페이먼츠 상점아이디 첫 글자에 t를 추가해서 로그인하시기 바랍니다. 예) tsi_lguplus</li>
+                        <li>테스트 결제건에 대한 <a href="https://app.tosspayments.com/" target="_blank">상점관리자</a> 접근은, 상점관리자 상단 '테스트 모드'를 활성화 하여서 접근할 수 있습니다.</li>
                     </ul>
                     <ul id="toss_cardtest_tip" class="scf_cardtest_tip_adm scf_cardtest_tip_adm_hide">
-                        <li>테스트 결제 시 <a href="https://app.tosspayments.com/" target="_blank">상점관리자</a> 로그인 정보는 실결제용 키와는 다르니 반드시 <b>[테스트] API 연동 키</b>로 로그인해야 합니다. 예) test_ck_toss</li>
+                        <li>테스트 결제건에 대한 <a href="https://app.tosspayments.com/" target="_blank">상점관리자</a> 접근은, 상점관리자 상단 '테스트 모드'를 활성화 하여서 접근할 수 있습니다.</li>
                     </ul>
                     <ul id="inicis_cardtest_tip" class="scf_cardtest_tip_adm scf_cardtest_tip_adm_hide">
                         <li><b>일반결제</b>의 테스트 사이트 mid는 <b>INIpayTest</b> 이며, <b>에스크로 결제</b>의 테스트 사이트 mid는 <b>iniescrow0</b> 입니다.</li>
@@ -2141,5 +2140,6 @@ if($default['de_iche_use'] || $default['de_vbank_use'] || $default['de_hp_use'] 
         }
     }
 }
+
 
 include_once (G5_ADMIN_PATH.'/admin.tail.php');

--- a/adm/shop_admin/orderform.php
+++ b/adm/shop_admin/orderform.php
@@ -509,39 +509,33 @@ add_javascript(G5_POSTCODE_JS, 0);    //다음 주소 js
                         <?php
                         if ($od['od_settle_case'] != '무통장') {
                             switch($od['od_pg']) {
-                                case 'lg':
-                                    $pg_url  = 'https://app.tosspayments.com';
-                                    $pg_test = '토스페이먼츠(구버전)';
-                                    if ($default['de_card_test']) {
-                                        $pg_url = 'https://pgweb.tosspayments.com/tmert';
-                                        $pg_test .= ' 테스트 ';
-                                    }
-                                    break;
                                 case 'inicis':
                                     $pg_url  = 'https://iniweb.inicis.com/';
-                                    $pg_test = 'KG이니시스';
+                                    $pg_test = 'KG이니시스 ';
                                     break;
                                 case 'KAKAOPAY':
                                     $pg_url  = 'https://mms.cnspay.co.kr';
-                                    $pg_test = 'KAKAOPAY';
+                                    $pg_test = 'KAKAOPAY ';
                                     break;
                                 case 'nicepay':
                                     $pg_url  = 'https://npg.nicepay.co.kr/';
-                                    $pg_test = 'NICEPAY';
+                                    $pg_test = 'NICEPAY ';
                                     break;
+                                case 'lg':
                                 case 'toss':
                                     $pg_url  = 'https://app.tosspayments.com';
                                     $pg_test = '토스페이먼츠 ';
+                                    // 상점관리자 로그인 후 상단 '테스트 모드' 활성화 시 테스트 화면 노출
                                     break;
                                 default:
-                                    $pg_url  = 'http://admin8.kcp.co.kr';
-                                    $pg_test = 'KCP';
+                                    $pg_url  = 'https://partner.kcp.co.kr';
+                                    $pg_test = 'KCP ';
                                     if ($default['de_card_test']) {
                                         // 로그인 아이디 / 비번
                                         // 일반 : test1234 / test12345
                                         // 에스크로 : escrow / escrow913
-                                        $pg_url = 'http://testadmin8.kcp.co.kr';
-                                        $pg_test .= ' 테스트 ';
+                                        $pg_url = 'https://partner.kcp.co.kr';
+                                        $pg_test .= '테스트 ';
                                     }
 
                                 }

--- a/adm/shop_admin/orderform.php
+++ b/adm/shop_admin/orderform.php
@@ -534,7 +534,7 @@ add_javascript(G5_POSTCODE_JS, 0);    //다음 주소 js
                                         // 로그인 아이디 / 비번
                                         // 일반 : test1234 / test12345
                                         // 에스크로 : escrow / escrow913
-                                        $pg_url = 'https://partner.kcp.co.kr';
+                                        $pg_url = 'https://testpartner.kcp.co.kr';
                                         $pg_test .= '테스트 ';
                                     }
 


### PR DESCRIPTION
2025년 9월 22일부터 토스페이먼츠 상점관리자에 테스트모드가 추가되어,
기존 (구)상점관리자의 테스트상점관리자를 대체하게 되었습니다.

이에, (구)상점관리자 URL을 제거하고 (신)상점관리자 URL로 통일하며,
여백이 있는 페이지의 경우 테스트모드 안내 문구를 추가하였습니다.

**해당 PR이 merge 되고 배포되는 릴리즈에서는, 공지에 아래 내용을 적당히 첨부하여 주시기 바랍니다.**
```
안녕하세요, 토스페이먼츠입니다.
2025년 9월 22일부터 **테스트 상점관리자** 서비스를 제공합니다.

기존 개발자센터에서 확인하실 수 있었던 제한적인 결제 내역보다,
더 실제 환경에 가까운 테스트를 진행하실 수 있도록
라이브 상점관리자 수준의 **결제 내역 및 정산 건별 내역**을 지원합니다.

상점관리자 화면 우측 상단의 토글 버튼을 켜시면
접속한 라이브 MID에 연결된 **tMID 상점관리자**로 전환되며,
개발자센터에서 제공된 **테스트키로 발생한 거래 건**들을 확인하실 수 있습니다.

다만, 테스트 상점관리자에서는 일부 기능만 선별적으로 제공되므로
라이브 상점관리자 화면과 차이가 있을 수 있습니다.
또한 수수료 등 일부 상점 정보가 노출되지 않는 경우에는
토스페이먼츠로 문의 주시면 신속히 확인 후 조치해드리겠습니다.

감사합니다.
```

—————————————

또한, NHN KCP의 경우 (구)상점관리자 서비스가 종료되었기에 (신)파트너관리자로 URL을 변경하였습니다.